### PR TITLE
fix(deps): pina three em ~0.182.0 p/ peer @google/model-viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@types/nodemailer": "^8.0.0",
-    "@types/three": "^0.184.1",
+    "@types/three": "^0.182.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-autoplay": "^8.6.0",
@@ -45,7 +45,7 @@
     "rough-notation": "^0.5.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "three": "^0.184.0",
+    "three": "^0.182.0",
     "vaul": "^1.1.2",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
## Contexto

Após o PR #10 (`fix-globo`), foi adicionado `three@^0.184.0` ao topo do `package.json` para suportar `react-globe.gl` no globo da `/sobre`.

Isso gerou warnings em dev nos componentes `model-viewer` (`CaixaHome3d`, `OptimizedEmbalagem3d`):

```
Element model-viewer scheduled an update (...) causing a new update to be scheduled
Please ensure that the container has a non-static position
```

## Causa raiz

`@google/model-viewer@4.2.0` declara:

```json
"peerDependencies": { "three": "^0.182.0" }
```

Em semver, para versões `0.x.y`, o caret é restrito ao mesmo minor:
- `^0.182.0` ⇒ `>=0.182.0 <0.183.0`
- `0.184.0` está **fora** do range

A versão mais recente do `@google/model-viewer` continua com o mesmo peer, então a solução correta é alinhar o `three` em vez de subir o `model-viewer`.

## Mudanças

```diff
-    "@types/three": "^0.184.1",
+    "@types/three": "^0.182.0",
-    "three": "^0.184.0",
+    "three": "^0.182.0",
```

## Compatibilidade

| Lib | Peer requirement | 0.182.0 |
|---|---|---|
| `@google/model-viewer@4.2.0` | `three: ^0.182.0` | ✅ |
| `globe.gl@2.45.3` | `three: >=0.179 <1` | ✅ |
| `@monogrid/gainmap-js@3.4.0` | `three: >=0.159.0` | ✅ |
| `three-conic-polygon-geometry@2.1.2` | `three: 2` (=>=0.72.0) | ✅ |

`npm ls three` agora retorna versão única deduplicada em toda árvore.

## Validação

- ✅ Home `/` — `CaixaHome3d` (caixa azul "Onde tem envase...") carrega normalmente
- ✅ `/sobre` — globo branco translúcido + continentes funcionando
- ✅ 0 errors no console
- ✅ Type check: clean

Warnings residuais (`Lit is in dev mode`) são intrínsecos da lib em desenvolvimento e desaparecem em build de produção.