### PR TITLE
fix: resiliência de WebGL nos modelos 3D

### DIFF
--- a/components/layout/navbarDesktop.tsx
+++ b/components/layout/navbarDesktop.tsx
@@ -125,7 +125,12 @@ export default function NavbarDesktop() {
       <NavigationMenuList className='flex h-full w-7xl items-center justify-center'>
         <NavigationMenuItem className='h-full'>
           <Link href='/'>
-            <Image src={logoProfills} alt='Logo Profills' className='h-full' />
+            <Image
+              src={logoProfills}
+              alt='Logo Profills'
+              priority
+              className='h-full'
+            />
           </Link>
         </NavigationMenuItem>
         <div className='flex h-full w-full items-center justify-center gap-2'>

--- a/components/layout/navbarMobile.tsx
+++ b/components/layout/navbarMobile.tsx
@@ -176,6 +176,7 @@ export default function NavbarMobile() {
           <Image
             src={logoProfills}
             alt='Logo Profills'
+            priority
             className='h-8 w-auto object-contain'
           />
         </Link>

--- a/components/modelo3d/WebGLFallback.test.tsx
+++ b/components/modelo3d/WebGLFallback.test.tsx
@@ -11,6 +11,9 @@ describe('WebGLFallback', () => {
     expect(
       screen.getByText(/visualização 3d indisponível/i)
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/ative a aceleração de gráficos/i)
+    ).toBeInTheDocument();
   });
 
   it('aplica o estilo da variante dark', () => {

--- a/components/modelo3d/WebGLFallback.test.tsx
+++ b/components/modelo3d/WebGLFallback.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WebGLFallback } from './WebGLFallback';
+
+describe('WebGLFallback', () => {
+  it('renderiza a mensagem de indisponibilidade', () => {
+    render(<WebGLFallback />);
+
+    expect(screen.getByTestId('webgl-fallback')).toBeInTheDocument();
+    expect(
+      screen.getByText(/visualização 3d indisponível/i)
+    ).toBeInTheDocument();
+  });
+
+  it('aplica o estilo da variante dark', () => {
+    render(<WebGLFallback variant='dark' />);
+
+    expect(screen.getByTestId('webgl-fallback')).toHaveClass('bg-white/5');
+  });
+});

--- a/components/modelo3d/WebGLFallback.tsx
+++ b/components/modelo3d/WebGLFallback.tsx
@@ -40,7 +40,11 @@ export function WebGLFallback({
         Visualização 3D indisponível
       </span>
       <span className={`mt-2 text-xs leading-relaxed ${s.text}`}>
-        Seu dispositivo ou navegador não suporta a visualização interativa.
+        Seu navegador está com a aceleração de hardware (WebGL) desativada.
+      </span>
+      <span className={`mt-1 text-xs leading-relaxed ${s.text}`}>
+        Ative a aceleração de gráficos nas configurações do navegador para ver o
+        modelo em 3D.
       </span>
     </div>
   );

--- a/components/modelo3d/WebGLFallback.tsx
+++ b/components/modelo3d/WebGLFallback.tsx
@@ -1,0 +1,47 @@
+import { Box } from 'lucide-react';
+
+interface WebGLFallbackProps {
+  className?: string;
+  variant?: 'dark' | 'light';
+}
+
+const variantStyles = {
+  dark: {
+    card: 'border-white/10 bg-white/5',
+    iconWrap: 'border-accent/30 bg-accent/10',
+    icon: 'text-accent',
+    title: 'text-white',
+    text: 'text-white/60',
+  },
+  light: {
+    card: 'border-border bg-muted',
+    iconWrap: 'border-border bg-background',
+    icon: 'text-muted-foreground',
+    title: 'text-foreground',
+    text: 'text-muted-foreground',
+  },
+} as const;
+
+export function WebGLFallback({
+  className = '',
+  variant = 'light',
+}: WebGLFallbackProps) {
+  const s = variantStyles[variant];
+
+  return (
+    <div
+      data-testid='webgl-fallback'
+      className={`flex min-h-[220px] w-full max-w-sm flex-col items-center justify-center rounded-3xl border px-6 py-8 text-center backdrop-blur-sm ${s.card} ${className}`}>
+      <div
+        className={`flex h-14 w-14 items-center justify-center rounded-full border ${s.iconWrap}`}>
+        <Box className={`h-7 w-7 ${s.icon}`} />
+      </div>
+      <span className={`mt-4 text-sm font-semibold tracking-wide ${s.title}`}>
+        Visualização 3D indisponível
+      </span>
+      <span className={`mt-2 text-xs leading-relaxed ${s.text}`}>
+        Seu dispositivo ou navegador não suporta a visualização interativa.
+      </span>
+    </div>
+  );
+}

--- a/components/modelo3d/caixaHome3d.test.tsx
+++ b/components/modelo3d/caixaHome3d.test.tsx
@@ -19,6 +19,7 @@ describe('CaixaHome3d', () => {
       isLoaded: false,
       shouldRender: false,
       hasBeenLoaded: false,
+      webglSupported: true,
       handleModelLoad: vi.fn(),
       handleModelError: vi.fn(),
     });
@@ -39,5 +40,24 @@ describe('CaixaHome3d', () => {
     expect(container.querySelector('[style*="height: 320px"]')).toHaveStyle({
       height: '320px',
     });
+  });
+
+  it('mostra o WebGLFallback quando WebGL não está disponível', () => {
+    mockedUseOptimized3DModel.mockReturnValue({
+      containerRef: { current: null },
+      modelViewerRef: { current: null },
+      isVisible: false,
+      isLoaded: false,
+      shouldRender: false,
+      hasBeenLoaded: false,
+      webglSupported: false,
+      handleModelLoad: vi.fn(),
+      handleModelError: vi.fn(),
+    });
+
+    render(<CaixaHome3d isMobile={true} />);
+
+    expect(screen.getByTestId('webgl-fallback')).toBeInTheDocument();
+    expect(screen.queryByText(/carregando modelo 3d/i)).not.toBeInTheDocument();
   });
 });

--- a/components/modelo3d/caixaHome3d.tsx
+++ b/components/modelo3d/caixaHome3d.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useOptimized3DModel } from '@/components/modelo3d/hooks/useOptimized3DModel';
+import { WebGLFallback } from '@/components/modelo3d/WebGLFallback';
 
 interface CaixaHome3dProps {
   modelSrc?: string;
@@ -34,6 +35,7 @@ export function CaixaHome3d({
     isVisible,
     isLoaded,
     shouldRender,
+    webglSupported,
     handleModelLoad,
     handleModelError
   } = useOptimized3DModel({
@@ -63,7 +65,7 @@ export function CaixaHome3d({
         />
       )}
 
-      {shouldRender && (
+      {shouldRender && webglSupported !== false && (
         // @ts-expect-error O modelo 3D model-viewer não tem tipos nativos para React
         <model-viewer
           ref={modelViewerRef}
@@ -99,7 +101,7 @@ export function CaixaHome3d({
         </model-viewer>
       )}
 
-      {!posterSrc && (!shouldRender || !isLoaded) && (
+      {!posterSrc && webglSupported !== false && (!shouldRender || !isLoaded) && (
         <div
           className='flex w-full items-center justify-center'
           style={{ height: isMobile ? '320px' : '100%' }}>
@@ -119,6 +121,9 @@ export function CaixaHome3d({
             </div>
           )}
         </div>
+      )}
+      {!posterSrc && webglSupported === false && (
+        <WebGLFallback variant='dark' />
       )}
     </div>
   );

--- a/components/modelo3d/hooks/useOptimized3DModel.test.ts
+++ b/components/modelo3d/hooks/useOptimized3DModel.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./webglSupport', () => ({
+  isWebGLAvailable: vi.fn(),
+}));
+
+import { useOptimized3DModel } from './useOptimized3DModel';
+import { isWebGLAvailable } from './webglSupport';
+
+const mockedIsWebGLAvailable = vi.mocked(isWebGLAvailable);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOptimized3DModel', () => {
+  it('expõe webglSupported=false quando WebGL não está disponível', async () => {
+    mockedIsWebGLAvailable.mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useOptimized3DModel({ src: '/modelo.glb' })
+    );
+
+    await waitFor(() => expect(result.current.webglSupported).toBe(false));
+  });
+
+  it('expõe webglSupported=true quando WebGL está disponível', async () => {
+    mockedIsWebGLAvailable.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useOptimized3DModel({ src: '/modelo.glb' })
+    );
+
+    await waitFor(() => expect(result.current.webglSupported).toBe(true));
+  });
+});

--- a/components/modelo3d/hooks/useOptimized3DModel.ts
+++ b/components/modelo3d/hooks/useOptimized3DModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ModelViewerElement } from '@google/model-viewer';
+import { isWebGLAvailable } from './webglSupport';
 
 // Cache global para modelos 3D já carregados
 const modelCache = new Map<string, boolean>();
@@ -25,6 +26,12 @@ export function useOptimized3DModel({
   const [isLoaded, setIsLoaded] = useState(false);
   const [shouldRender, setShouldRender] = useState(false);
   const [hasBeenLoaded, setHasBeenLoaded] = useState(false);
+  const [webglSupported, setWebglSupported] = useState<boolean | null>(null);
+
+  // Detecta suporte a WebGL uma vez no client.
+  useEffect(() => {
+    setWebglSupported(isWebGLAvailable());
+  }, []);
 
   // Incrementa contador de instâncias
   useEffect(() => {
@@ -94,7 +101,7 @@ export function useOptimized3DModel({
 
   // Carrega model-viewer dinamicamente apenas quando necessário
   useEffect(() => {
-    if (!shouldRender || isLoaded) return;
+    if (!shouldRender || isLoaded || webglSupported !== true) return;
 
     const loadModelViewer = async () => {
       try {
@@ -110,7 +117,7 @@ export function useOptimized3DModel({
     };
 
     loadModelViewer();
-  }, [shouldRender, isLoaded]);
+  }, [shouldRender, isLoaded, webglSupported]);
 
   // Cleanup de estilos compartilhado
   useEffect(() => {
@@ -190,6 +197,7 @@ export function useOptimized3DModel({
     isLoaded,
     shouldRender: shouldRender || hasBeenLoaded, // Sempre renderiza se já foi carregado uma vez
     hasBeenLoaded,
+    webglSupported,
     handleModelLoad,
     handleModelError
   };

--- a/components/modelo3d/hooks/webglSupport.test.ts
+++ b/components/modelo3d/hooks/webglSupport.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isWebGLAvailable, resetWebGLCache } from './webglSupport';
+
+afterEach(() => {
+  resetWebGLCache();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('isWebGLAvailable', () => {
+  it('retorna true quando o canvas fornece um contexto webgl', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      {} as unknown as WebGL2RenderingContext
+    );
+    expect(isWebGLAvailable()).toBe(true);
+  });
+
+  it('retorna false quando nenhum contexto webgl é criado', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    expect(isWebGLAvailable()).toBe(false);
+  });
+
+  it('retorna false quando getContext lança', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () => {
+        throw new Error('webgl disabled');
+      }
+    );
+    expect(isWebGLAvailable()).toBe(false);
+  });
+
+  it('assume true em ambiente sem window (SSR)', () => {
+    vi.stubGlobal('window', undefined);
+    expect(isWebGLAvailable()).toBe(true);
+  });
+});

--- a/components/modelo3d/hooks/webglSupport.ts
+++ b/components/modelo3d/hooks/webglSupport.ts
@@ -1,0 +1,28 @@
+let cached: boolean | null = null;
+
+/**
+ * Detecta suporte a WebGL criando um contexto descartável.
+ * Resultado memoizado por sessão (no client).
+ */
+export function isWebGLAvailable(): boolean {
+  if (cached !== null) return cached;
+
+  // SSR: assume suporte; a detecção real roda no client e não é memoizada aqui.
+  if (typeof window === 'undefined') return true;
+
+  try {
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl');
+    cached = gl !== null;
+  } catch {
+    // getContext pode lançar quando WebGL está bloqueado — isso significa indisponível.
+    cached = false;
+  }
+
+  return cached;
+}
+
+/** Apenas para testes: limpa o resultado memoizado. */
+export function resetWebGLCache(): void {
+  cached = null;
+}

--- a/components/modelo3d/optimizedEmbalagem3d.test.tsx
+++ b/components/modelo3d/optimizedEmbalagem3d.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { OptimizedEmbalagem3d } from './optimizedEmbalagem3d';
+import { useOptimized3DModel } from './hooks/useOptimized3DModel';
+
+vi.mock('./hooks/useOptimized3DModel', () => ({
+  useOptimized3DModel: vi.fn(),
+}));
+
+const mockedUseOptimized3DModel = vi.mocked(useOptimized3DModel);
+
+describe('OptimizedEmbalagem3d', () => {
+  it('mostra o WebGLFallback quando WebGL não está disponível', () => {
+    mockedUseOptimized3DModel.mockReturnValue({
+      containerRef: { current: null },
+      modelViewerRef: { current: null },
+      isVisible: false,
+      isLoaded: false,
+      shouldRender: false,
+      hasBeenLoaded: false,
+      webglSupported: false,
+      handleModelLoad: vi.fn(),
+      handleModelError: vi.fn(),
+    });
+
+    render(<OptimizedEmbalagem3d />);
+
+    expect(screen.getByTestId('webgl-fallback')).toBeInTheDocument();
+  });
+
+  it('mostra o placeholder de loading enquanto detecta WebGL', () => {
+    mockedUseOptimized3DModel.mockReturnValue({
+      containerRef: { current: null },
+      modelViewerRef: { current: null },
+      isVisible: true,
+      isLoaded: false,
+      shouldRender: false,
+      hasBeenLoaded: false,
+      webglSupported: null,
+      handleModelLoad: vi.fn(),
+      handleModelError: vi.fn(),
+    });
+
+    render(<OptimizedEmbalagem3d />);
+
+    expect(screen.queryByTestId('webgl-fallback')).not.toBeInTheDocument();
+    expect(screen.getByText(/carregando modelo 3d/i)).toBeInTheDocument();
+  });
+});

--- a/components/modelo3d/optimizedEmbalagem3d.tsx
+++ b/components/modelo3d/optimizedEmbalagem3d.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 
+import { WebGLFallback } from '@/components/modelo3d/WebGLFallback';
 import { useOptimized3DModel } from '@/components/modelo3d/hooks/useOptimized3DModel';
 
 interface OptimizedEmbalagem3dProps {
@@ -30,6 +31,7 @@ export function OptimizedEmbalagem3d({
     isLoaded,
     shouldRender,
     hasBeenLoaded,
+    webglSupported,
     handleModelLoad,
     handleModelError
   } = useOptimized3DModel({
@@ -43,7 +45,7 @@ export function OptimizedEmbalagem3d({
       ref={containerRef}
       className={`flex h-full w-full items-center justify-center ${className}`}>
       {/* Model-viewer: Uma vez carregado, sempre renderizado mas com visibilidade controlada */}
-      {shouldRender && isLoaded && (
+      {shouldRender && isLoaded && webglSupported !== false && (
         // @ts-expect-error O modelo 3D model-viewer não tem tipos nativos para React
         <model-viewer
           ref={modelViewerRef}
@@ -82,7 +84,7 @@ export function OptimizedEmbalagem3d({
       )}
 
       {/* Placeholder: Só mostra se o modelo nunca foi carregado */}
-      {(!shouldRender || !isLoaded) && (
+      {webglSupported !== false && (!shouldRender || !isLoaded) && (
         <div
           className='flex h-full w-full items-center justify-center'
           style={{ minHeight: '250px' }}>
@@ -112,6 +114,10 @@ export function OptimizedEmbalagem3d({
             </div>
           )}
         </div>
+      )}
+
+      {webglSupported === false && !posterSrc && (
+        <WebGLFallback variant='light' />
       )}
     </div>
   );

--- a/docs/superpowers/plans/2026-05-19-resiliencia-webgl-modelo3d.md
+++ b/docs/superpowers/plans/2026-05-19-resiliencia-webgl-modelo3d.md
@@ -1,0 +1,704 @@
+# Resiliência de WebGL nos modelos 3D — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detectar a ausência de WebGL e degradar os componentes 3D para um fallback estático, eliminando na raiz os erros de contexto WebGL e o `unhandledRejection` do three.js.
+
+**Architecture:** Um util `isWebGLAvailable()` detecta suporte a WebGL criando um contexto descartável. O hook `useOptimized3DModel` expõe `webglSupported`; quando `false`, não importa `@google/model-viewer` nem renderiza `<model-viewer>`. Os componentes passam a tratar três estados (carregando / carregado / indisponível) e exibem um componente compartilhado `WebGLFallback` no estado indisponível.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, `@google/model-viewer`, Vitest + Testing Library, Tailwind v4, lucide-react.
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `components/modelo3d/hooks/webglSupport.ts` (novo) | Detecção memoizada de suporte a WebGL |
+| `components/modelo3d/hooks/webglSupport.test.ts` (novo) | Testes do util |
+| `components/modelo3d/hooks/useOptimized3DModel.ts` | Expõe `webglSupported`, gate do import |
+| `components/modelo3d/hooks/useOptimized3DModel.test.ts` (novo) | Testa propagação de `webglSupported` |
+| `components/modelo3d/WebGLFallback.tsx` (novo) | Placeholder compartilhado de indisponibilidade |
+| `components/modelo3d/WebGLFallback.test.tsx` (novo) | Testes do fallback |
+| `components/modelo3d/caixaHome3d.tsx` | Wire do fallback (variante dark) |
+| `components/modelo3d/caixaHome3d.test.tsx` | Atualiza mock + caso WebGL indisponível |
+| `components/modelo3d/optimizedEmbalagem3d.tsx` | Wire do fallback (variante light) |
+| `components/modelo3d/optimizedEmbalagem3d.test.tsx` (novo) | Testes de render do fallback |
+| `vitest.setup.ts` | Stub global de `IntersectionObserver` |
+| `components/layout/navbarDesktop.tsx` | `priority` no logo (fix LCP) |
+| `components/layout/navbarMobile.tsx` | `priority` no logo (fix LCP) |
+
+---
+
+## Task 1: Util de detecção de WebGL
+
+**Files:**
+- Create: `components/modelo3d/hooks/webglSupport.ts`
+- Test: `components/modelo3d/hooks/webglSupport.test.ts`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Em `components/modelo3d/hooks/webglSupport.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isWebGLAvailable, resetWebGLCache } from './webglSupport';
+
+afterEach(() => {
+  resetWebGLCache();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('isWebGLAvailable', () => {
+  it('retorna true quando o canvas fornece um contexto webgl', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      {} as unknown as WebGL2RenderingContext
+    );
+    expect(isWebGLAvailable()).toBe(true);
+  });
+
+  it('retorna false quando nenhum contexto webgl é criado', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    expect(isWebGLAvailable()).toBe(false);
+  });
+
+  it('retorna false quando getContext lança', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () => {
+        throw new Error('webgl disabled');
+      }
+    );
+    expect(isWebGLAvailable()).toBe(false);
+  });
+
+  it('assume true em ambiente sem window (SSR)', () => {
+    vi.stubGlobal('window', undefined);
+    expect(isWebGLAvailable()).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Rodar os testes para confirmar que falham**
+
+Run: `bun run test webglSupport`
+Expected: FAIL — `Failed to resolve import "./webglSupport"`.
+
+- [ ] **Step 3: Implementar o util**
+
+Em `components/modelo3d/hooks/webglSupport.ts`:
+
+```ts
+let cached: boolean | null = null;
+
+/**
+ * Detecta suporte a WebGL criando um contexto descartável.
+ * Resultado memoizado por sessão (no client).
+ */
+export function isWebGLAvailable(): boolean {
+  if (cached !== null) return cached;
+
+  // SSR: assume suporte; a detecção real roda no client e não é memoizada aqui.
+  if (typeof window === 'undefined') return true;
+
+  try {
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl');
+    cached = gl !== null;
+  } catch {
+    // getContext pode lançar quando WebGL está bloqueado — isso significa indisponível.
+    cached = false;
+  }
+
+  return cached;
+}
+
+/** Apenas para testes: limpa o resultado memoizado. */
+export function resetWebGLCache(): void {
+  cached = null;
+}
+```
+
+- [ ] **Step 4: Rodar os testes para confirmar que passam**
+
+Run: `bun run test webglSupport`
+Expected: PASS — 4 testes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/modelo3d/hooks/webglSupport.ts components/modelo3d/hooks/webglSupport.test.ts
+git commit -m "feat: adiciona detecção de suporte a WebGL"
+```
+
+---
+
+## Task 2: Expor `webglSupported` em `useOptimized3DModel`
+
+**Files:**
+- Modify: `vitest.setup.ts`
+- Modify: `components/modelo3d/hooks/useOptimized3DModel.ts`
+- Test: `components/modelo3d/hooks/useOptimized3DModel.test.ts`
+
+- [ ] **Step 1: Adicionar stub de `IntersectionObserver` ao setup de testes**
+
+O hook instancia `new IntersectionObserver(...)`, que jsdom não fornece. Substituir o conteúdo de `vitest.setup.ts` por:
+
+```ts
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+class IntersectionObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);
+```
+
+- [ ] **Step 2: Escrever o teste que falha**
+
+Em `components/modelo3d/hooks/useOptimized3DModel.test.ts`:
+
+```ts
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./webglSupport', () => ({
+  isWebGLAvailable: vi.fn(),
+}));
+
+import { useOptimized3DModel } from './useOptimized3DModel';
+import { isWebGLAvailable } from './webglSupport';
+
+const mockedIsWebGLAvailable = vi.mocked(isWebGLAvailable);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOptimized3DModel', () => {
+  it('expõe webglSupported=false quando WebGL não está disponível', async () => {
+    mockedIsWebGLAvailable.mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useOptimized3DModel({ src: '/modelo.glb' })
+    );
+
+    await waitFor(() => expect(result.current.webglSupported).toBe(false));
+  });
+
+  it('expõe webglSupported=true quando WebGL está disponível', async () => {
+    mockedIsWebGLAvailable.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useOptimized3DModel({ src: '/modelo.glb' })
+    );
+
+    await waitFor(() => expect(result.current.webglSupported).toBe(true));
+  });
+});
+```
+
+- [ ] **Step 3: Rodar o teste para confirmar que falha**
+
+Run: `bun run test useOptimized3DModel`
+Expected: FAIL — `result.current.webglSupported` é `undefined`.
+
+- [ ] **Step 4: Implementar `webglSupported` no hook**
+
+Em `components/modelo3d/hooks/useOptimized3DModel.ts`:
+
+4a. Adicionar o import no topo, junto aos imports existentes:
+
+```ts
+import { isWebGLAvailable } from './webglSupport';
+```
+
+4b. Adicionar o estado, logo após `const [hasBeenLoaded, setHasBeenLoaded] = useState(false);` (linha ~27):
+
+```ts
+  const [webglSupported, setWebglSupported] = useState<boolean | null>(null);
+
+  // Detecta suporte a WebGL uma vez no client.
+  useEffect(() => {
+    setWebglSupported(isWebGLAvailable());
+  }, []);
+```
+
+4c. Alterar a guarda da `useEffect` que importa o model-viewer (linha ~97). Trocar:
+
+```ts
+    if (!shouldRender || isLoaded) return;
+```
+
+por:
+
+```ts
+    if (!shouldRender || isLoaded || webglSupported !== true) return;
+```
+
+e incluir `webglSupported` no array de dependências dessa `useEffect` (linha ~113):
+
+```ts
+  }, [shouldRender, isLoaded, webglSupported]);
+```
+
+4d. Adicionar `webglSupported` ao objeto retornado (bloco `return { ... }`, linha ~186):
+
+```ts
+  return {
+    containerRef,
+    modelViewerRef,
+    isVisible,
+    isLoaded,
+    shouldRender: shouldRender || hasBeenLoaded,
+    hasBeenLoaded,
+    webglSupported,
+    handleModelLoad,
+    handleModelError
+  };
+```
+
+- [ ] **Step 5: Rodar o teste para confirmar que passa**
+
+Run: `bun run test useOptimized3DModel`
+Expected: PASS — 2 testes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vitest.setup.ts components/modelo3d/hooks/useOptimized3DModel.ts components/modelo3d/hooks/useOptimized3DModel.test.ts
+git commit -m "feat: expõe webglSupported no useOptimized3DModel"
+```
+
+---
+
+## Task 3: Componente `WebGLFallback`
+
+**Files:**
+- Create: `components/modelo3d/WebGLFallback.tsx`
+- Test: `components/modelo3d/WebGLFallback.test.tsx`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Em `components/modelo3d/WebGLFallback.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WebGLFallback } from './WebGLFallback';
+
+describe('WebGLFallback', () => {
+  it('renderiza a mensagem de indisponibilidade', () => {
+    render(<WebGLFallback />);
+
+    expect(screen.getByTestId('webgl-fallback')).toBeInTheDocument();
+    expect(
+      screen.getByText(/visualização 3d indisponível/i)
+    ).toBeInTheDocument();
+  });
+
+  it('aplica o estilo da variante dark', () => {
+    render(<WebGLFallback variant='dark' />);
+
+    expect(screen.getByTestId('webgl-fallback')).toHaveClass('bg-white/5');
+  });
+});
+```
+
+- [ ] **Step 2: Rodar os testes para confirmar que falham**
+
+Run: `bun run test WebGLFallback`
+Expected: FAIL — `Failed to resolve import "./WebGLFallback"`.
+
+- [ ] **Step 3: Implementar o componente**
+
+Em `components/modelo3d/WebGLFallback.tsx`:
+
+```tsx
+import { Box } from 'lucide-react';
+
+interface WebGLFallbackProps {
+  className?: string;
+  variant?: 'dark' | 'light';
+}
+
+const variantStyles = {
+  dark: {
+    card: 'border-white/10 bg-white/5',
+    iconWrap: 'border-accent/30 bg-accent/10',
+    icon: 'text-accent',
+    title: 'text-white',
+    text: 'text-white/60',
+  },
+  light: {
+    card: 'border-border bg-muted',
+    iconWrap: 'border-border bg-background',
+    icon: 'text-muted-foreground',
+    title: 'text-foreground',
+    text: 'text-muted-foreground',
+  },
+} as const;
+
+export function WebGLFallback({
+  className = '',
+  variant = 'light',
+}: WebGLFallbackProps) {
+  const s = variantStyles[variant];
+
+  return (
+    <div
+      data-testid='webgl-fallback'
+      className={`flex min-h-[220px] w-full max-w-sm flex-col items-center justify-center rounded-3xl border px-6 py-8 text-center backdrop-blur-sm ${s.card} ${className}`}>
+      <div
+        className={`flex h-14 w-14 items-center justify-center rounded-full border ${s.iconWrap}`}>
+        <Box className={`h-7 w-7 ${s.icon}`} />
+      </div>
+      <span
+        className={`mt-4 text-sm font-semibold tracking-wide ${s.title}`}>
+        Visualização 3D indisponível
+      </span>
+      <span className={`mt-2 text-xs leading-relaxed ${s.text}`}>
+        Seu dispositivo ou navegador não suporta a visualização interativa.
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Rodar os testes para confirmar que passam**
+
+Run: `bun run test WebGLFallback`
+Expected: PASS — 2 testes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/modelo3d/WebGLFallback.tsx components/modelo3d/WebGLFallback.test.tsx
+git commit -m "feat: adiciona componente WebGLFallback"
+```
+
+---
+
+## Task 4: Integrar o fallback no `CaixaHome3d`
+
+**Files:**
+- Modify: `components/modelo3d/caixaHome3d.tsx`
+- Test: `components/modelo3d/caixaHome3d.test.tsx`
+
+- [ ] **Step 1: Atualizar o mock existente e adicionar o teste que falha**
+
+Em `components/modelo3d/caixaHome3d.test.tsx`:
+
+1a. No `mockReturnValue` do teste já existente (`shows a visible loading placeholder...`), adicionar a propriedade `webglSupported: true` ao objeto retornado (a falta dela quebra o tipo após a Task 2).
+
+1b. Adicionar este novo teste dentro do mesmo `describe`:
+
+```tsx
+  it('mostra o WebGLFallback quando WebGL não está disponível', () => {
+    mockedUseOptimized3DModel.mockReturnValue({
+      containerRef: { current: null },
+      modelViewerRef: { current: null },
+      isVisible: false,
+      isLoaded: false,
+      shouldRender: false,
+      hasBeenLoaded: false,
+      webglSupported: false,
+      handleModelLoad: vi.fn(),
+      handleModelError: vi.fn(),
+    });
+
+    render(<CaixaHome3d isMobile={true} />);
+
+    expect(screen.getByTestId('webgl-fallback')).toBeInTheDocument();
+    expect(screen.queryByText(/carregando modelo 3d/i)).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Rodar os testes para confirmar que o novo falha**
+
+Run: `bun run test caixaHome3d`
+Expected: FAIL no novo teste — `webgl-fallback` não encontrado.
+
+- [ ] **Step 3: Integrar o fallback no componente**
+
+Em `components/modelo3d/caixaHome3d.tsx`:
+
+3a. Adicionar o import (junto aos imports existentes):
+
+```tsx
+import { WebGLFallback } from '@/components/modelo3d/WebGLFallback';
+```
+
+3b. Adicionar `webglSupported` à desestruturação do hook (bloco `const { ... } = useOptimized3DModel(...)`):
+
+```tsx
+  const {
+    containerRef,
+    modelViewerRef,
+    isVisible,
+    isLoaded,
+    shouldRender,
+    webglSupported,
+    handleModelLoad,
+    handleModelError
+  } = useOptimized3DModel({
+```
+
+3c. Alterar a guarda do `<model-viewer>`. Trocar a linha `{shouldRender && (` por:
+
+```tsx
+      {shouldRender && webglSupported !== false && (
+```
+
+3d. Alterar a guarda do placeholder de loading. Trocar:
+
+```tsx
+      {!posterSrc && (!shouldRender || !isLoaded) && (
+```
+
+por:
+
+```tsx
+      {!posterSrc && webglSupported !== false && (!shouldRender || !isLoaded) && (
+```
+
+3e. Adicionar o bloco de fallback imediatamente antes do fechamento do `</div>` externo (logo após o bloco do placeholder de loading):
+
+```tsx
+      {!posterSrc && webglSupported === false && (
+        <WebGLFallback variant='dark' />
+      )}
+```
+
+- [ ] **Step 4: Rodar os testes para confirmar que passam**
+
+Run: `bun run test caixaHome3d`
+Expected: PASS — 2 testes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/modelo3d/caixaHome3d.tsx components/modelo3d/caixaHome3d.test.tsx
+git commit -m "feat: exibe WebGLFallback no CaixaHome3d sem WebGL"
+```
+
+---
+
+## Task 5: Integrar o fallback no `OptimizedEmbalagem3d`
+
+**Files:**
+- Modify: `components/modelo3d/optimizedEmbalagem3d.tsx`
+- Test: `components/modelo3d/optimizedEmbalagem3d.test.tsx`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Em `components/modelo3d/optimizedEmbalagem3d.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { OptimizedEmbalagem3d } from './optimizedEmbalagem3d';
+import { useOptimized3DModel } from './hooks/useOptimized3DModel';
+
+vi.mock('./hooks/useOptimized3DModel', () => ({
+  useOptimized3DModel: vi.fn(),
+}));
+
+const mockedUseOptimized3DModel = vi.mocked(useOptimized3DModel);
+
+describe('OptimizedEmbalagem3d', () => {
+  it('mostra o WebGLFallback quando WebGL não está disponível', () => {
+    mockedUseOptimized3DModel.mockReturnValue({
+      containerRef: { current: null },
+      modelViewerRef: { current: null },
+      isVisible: false,
+      isLoaded: false,
+      shouldRender: false,
+      hasBeenLoaded: false,
+      webglSupported: false,
+      handleModelLoad: vi.fn(),
+      handleModelError: vi.fn(),
+    });
+
+    render(<OptimizedEmbalagem3d />);
+
+    expect(screen.getByTestId('webgl-fallback')).toBeInTheDocument();
+  });
+
+  it('mostra o placeholder de loading enquanto detecta WebGL', () => {
+    mockedUseOptimized3DModel.mockReturnValue({
+      containerRef: { current: null },
+      modelViewerRef: { current: null },
+      isVisible: true,
+      isLoaded: false,
+      shouldRender: false,
+      hasBeenLoaded: false,
+      webglSupported: null,
+      handleModelLoad: vi.fn(),
+      handleModelError: vi.fn(),
+    });
+
+    render(<OptimizedEmbalagem3d />);
+
+    expect(screen.queryByTestId('webgl-fallback')).not.toBeInTheDocument();
+    expect(screen.getByText(/carregando modelo 3d/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar os testes para confirmar que falham**
+
+Run: `bun run test optimizedEmbalagem3d`
+Expected: FAIL — `webgl-fallback` não encontrado / `webglSupported` ausente no tipo.
+
+- [ ] **Step 3: Integrar o fallback no componente**
+
+Em `components/modelo3d/optimizedEmbalagem3d.tsx`:
+
+3a. Adicionar o import (junto aos imports existentes):
+
+```tsx
+import { WebGLFallback } from '@/components/modelo3d/WebGLFallback';
+```
+
+3b. Adicionar `webglSupported` à desestruturação do hook:
+
+```tsx
+  const {
+    containerRef,
+    modelViewerRef,
+    isVisible,
+    isLoaded,
+    shouldRender,
+    hasBeenLoaded,
+    webglSupported,
+    handleModelLoad,
+    handleModelError
+  } = useOptimized3DModel({
+```
+
+3c. Alterar a guarda do `<model-viewer>`. Trocar `{shouldRender && isLoaded && (` por:
+
+```tsx
+      {shouldRender && isLoaded && webglSupported !== false && (
+```
+
+3d. Alterar a guarda do bloco de placeholder. Trocar:
+
+```tsx
+      {(!shouldRender || !isLoaded) && (
+```
+
+por:
+
+```tsx
+      {webglSupported !== false && (!shouldRender || !isLoaded) && (
+```
+
+3e. Adicionar o bloco de fallback imediatamente após o bloco de placeholder (antes do fechamento do `</div>` externo):
+
+```tsx
+      {webglSupported === false && !posterSrc && (
+        <WebGLFallback variant='light' />
+      )}
+```
+
+- [ ] **Step 4: Rodar os testes para confirmar que passam**
+
+Run: `bun run test optimizedEmbalagem3d`
+Expected: PASS — 2 testes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/modelo3d/optimizedEmbalagem3d.tsx components/modelo3d/optimizedEmbalagem3d.test.tsx
+git commit -m "feat: exibe WebGLFallback no OptimizedEmbalagem3d sem WebGL"
+```
+
+---
+
+## Task 6: Fix do aviso de LCP no logo
+
+O logo `logo-branco.png` é o LCP above the fold. `priority` no `next/image` aplica `loading="eager"` e `fetchpriority="high"`. Mudança trivial sem teste unitário — verificada via build/console.
+
+**Files:**
+- Modify: `components/layout/navbarDesktop.tsx:128`
+- Modify: `components/layout/navbarMobile.tsx:176`
+
+- [ ] **Step 1: Adicionar `priority` ao logo do navbar desktop**
+
+Em `components/layout/navbarDesktop.tsx`, trocar a linha 128:
+
+```tsx
+            <Image src={logoProfills} alt='Logo Profills' className='h-full' />
+```
+
+por:
+
+```tsx
+            <Image
+              src={logoProfills}
+              alt='Logo Profills'
+              priority
+              className='h-full'
+            />
+```
+
+- [ ] **Step 2: Adicionar `priority` ao logo do navbar mobile**
+
+Em `components/layout/navbarMobile.tsx`, no `<Image>` que começa na linha ~176 (o logo dentro do `<Link href='/'>`, NÃO o que está dentro do `DrawerHeader`), adicionar a prop `priority`:
+
+```tsx
+          <Image
+            src={logoProfills}
+            alt='Logo Profills'
+            priority
+            className='h-8 w-auto object-contain'
+          />
+```
+
+- [ ] **Step 3: Verificar o build**
+
+Run: `bun run build`
+Expected: build conclui sem erros.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/layout/navbarDesktop.tsx components/layout/navbarMobile.tsx
+git commit -m "perf: prioriza carregamento do logo (LCP)"
+```
+
+---
+
+## Verificação final
+
+- [ ] **Suite completa de testes**
+
+Run: `bun run test`
+Expected: todos os testes passam, incluindo os novos de `webglSupport`, `useOptimized3DModel`, `WebGLFallback`, `caixaHome3d` e `optimizedEmbalagem3d`.
+
+- [ ] **Lint**
+
+Run: `bun run lint`
+Expected: sem erros.
+
+- [ ] **Verificação manual (dev sem WebGL)**
+
+Run: `bun dev` e abrir `http://localhost:3000` num navegador sem aceleração de GPU.
+Expected: o terminal **não** mostra `THREE.WebGLRenderer: ... context could not be created` nem `unhandledRejection: ... isPresenting`. A página exibe o card "Visualização 3D indisponível" no lugar dos modelos 3D — sem spinner infinito.
+
+- [ ] **Verificação manual (dev com WebGL)**
+
+Run: `bun dev` num navegador com WebGL habilitado.
+Expected: os modelos 3D carregam e rotacionam normalmente; nenhum regressão visual.

--- a/docs/superpowers/specs/2026-05-19-resiliencia-webgl-modelo3d-design.md
+++ b/docs/superpowers/specs/2026-05-19-resiliencia-webgl-modelo3d-design.md
@@ -1,0 +1,117 @@
+# Resiliência de WebGL nos modelos 3D
+
+**Data:** 2026-05-19
+**Status:** Aprovado para planejamento
+
+## Contexto
+
+O site usa `@google/model-viewer` (que depende de `three.js`/WebGL) para exibir
+modelos 3D de embalagens. Em ambientes sem aceleração de GPU/WebGL, o dev server
+encaminha para o terminal uma cascata de erros:
+
+```
+THREE.WebGLRenderer: A WebGL context could not be created.
+  Sandboxed = yes, GL_VENDOR = Disabled, VENDOR = 0xffff
+unhandledRejection: TypeError: Cannot read properties of null (reading 'isPresenting')
+```
+
+### Cadeia causal
+
+1. O navegador não consegue criar um contexto WebGL (GPU desabilitada/bloqueada).
+2. O `THREE.WebGLRenderer` instanciado pelo `<model-viewer>` fica `null`.
+3. O loop de render / código WebXR do model-viewer continua lendo
+   `renderer.xr.isPresenting` num objeto `null`, disparando uma promise
+   rejeitada não tratada — repetida por instância/frame.
+4. O `onError` do `<model-viewer>` **não** captura isso, pois é uma rejection
+   interna do three.js, fora do ciclo de erro do custom element.
+
+Hoje não há detecção de capacidade WebGL. Qualquer visitante sem WebGL
+(GPU bloqueada, dispositivo low-end) vê o mesmo crash. Pior: como nenhum caller
+passa `posterSrc`, o `CaixaHome3d` exibe um spinner "Carregando modelo 3D..."
+que **gira indefinidamente**.
+
+## Objetivo
+
+Tornar os componentes 3D resilientes: detectar a ausência de WebGL e degradar
+graciosamente para um fallback estático, eliminando os erros na raiz — sem
+mascarar falhas com try/catch silencioso.
+
+## Decisões de design
+
+- **Fallback:** placeholder estilizado com ícone + mensagem
+  "Visualização 3D indisponível neste dispositivo". Estado terminal, sem
+  animação de loading. Sem necessidade de gerar assets.
+- **Escopo extra:** corrigir também o aviso de LCP do logo (above the fold).
+
+## Arquitetura
+
+### 1. Util de detecção — `isWebGLAvailable()`
+
+Novo arquivo (ex.: `components/modelo3d/hooks/webglSupport.ts`).
+
+- Cria um `<canvas>` descartável e tenta `getContext('webgl2')` e, em fallback,
+  `getContext('webgl')`.
+- Retorna `boolean`. Resultado memoizado em módulo (executa uma vez por sessão).
+- SSR-safe: se `typeof window === 'undefined'`, assume `true` (otimista; a
+  reavaliação real ocorre no client). A detecção definitiva roda em `useEffect`.
+
+### 2. `useOptimized3DModel` — novo estado `webglSupported`
+
+- Em `useEffect` (client-only), define `webglSupported: boolean | null`
+  (`null` = ainda não verificado).
+- A `useEffect` que importa `@google/model-viewer` (linha ~96) passa a só
+  executar quando `webglSupported === true`. Se `false`, **não importa a lib**
+  e **nunca renderiza** `<model-viewer>`.
+- O hook expõe `webglSupported` no retorno para os componentes.
+
+### 3. Componentes — três estados explícitos
+
+`CaixaHome3d` e `OptimizedEmbalagem3d` passam a tratar:
+
+| Estado            | Condição                              | Render                          |
+|-------------------|---------------------------------------|---------------------------------|
+| Carregando        | `webglSupported !== false && !isLoaded`| spinner / placeholder atual     |
+| Carregado         | `isLoaded`                            | `<model-viewer>`                |
+| **Indisponível**  | `webglSupported === false`            | placeholder de fallback novo    |
+
+- O `<model-viewer>` só renderiza com `webglSupported === true`.
+- Novo placeholder de fallback (componente compartilhado, ex.:
+  `WebGLFallback`): card estilizado consistente com o placeholder existente,
+  com ícone e a mensagem "Visualização 3D indisponível neste dispositivo".
+
+### 4. Fix de LCP do logo
+
+Adicionar `priority` ao `<Image>` do logo above the fold em
+`components/layout/navbarDesktop.tsx` e `components/layout/navbarMobile.tsx`
+(o logo `logo-branco.png`). `next/image` com `priority` aplica `loading="eager"`
+e `fetchpriority="high"`.
+
+## O que NÃO entra (YAGNI)
+
+- Geração de imagens-poster a partir dos `.glb`.
+- Tratamento de perda de contexto WebGL no meio da sessão (`webglcontextlost`) —
+  caso raro; pode ser endereçado depois se ocorrer.
+- Listener global de `unhandledrejection` — seria mascarar sintoma; a detecção
+  na raiz já impede a rejection.
+
+## Testes
+
+- `webglSupport.ts`: testar branch sem `window` (SSR) e mock de canvas
+  retornando contexto `null` vs. válido.
+- `useOptimized3DModel`: com `webglSupported === false`, garantir que o import
+  dinâmico não é chamado e `shouldRender` permanece sem o model-viewer.
+- `caixaHome3d.test.tsx` (já existe): adicionar caso de WebGL indisponível →
+  renderiza o fallback, não o spinner.
+- Verificação manual: `bun dev` num navegador sem GPU/WebGL → terminal limpo,
+  sem `unhandledRejection`; fallback visível na página.
+
+## Arquivos afetados
+
+- `components/modelo3d/hooks/webglSupport.ts` (novo)
+- `components/modelo3d/hooks/useOptimized3DModel.ts`
+- `components/modelo3d/caixaHome3d.tsx`
+- `components/modelo3d/optimizedEmbalagem3d.tsx`
+- `components/modelo3d/WebGLFallback.tsx` (novo — placeholder compartilhado)
+- `components/layout/navbarDesktop.tsx`
+- `components/layout/navbarMobile.tsx`
+- testes correspondentes

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@types/nodemailer": "^8.0.0",
-    "@types/three": "^0.184.1",
+    "@types/three": "0.182.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-autoplay": "^8.6.0",
@@ -46,7 +46,7 @@
     "rough-notation": "^0.5.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "three": "^0.184.0",
+    "three": "0.182.0",
     "vaul": "^1.1.2",
     "zod": "^4.4.3"
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+class IntersectionObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);


### PR DESCRIPTION
## Resumo

Torna os componentes 3D resilientes quando o WebGL não está disponível, eliminando na raiz a cascata de erros (`THREE.WebGLRenderer: A WebGL context could not be created`, `unhandledRejection: Cannot read properties of null (reading 'isPresenting')`) e o spinner de loading infinito.

- **Detecção de WebGL** — novo util `isWebGLAvailable()` cria um contexto descartável; resultado memoizado por sessão.
- **`useOptimized3DModel`** expõe `webglSupported`. Sem WebGL, **não importa** `@google/model-viewer` nem renderiza `<model-viewer>` — three.js nunca roda, sem promise rejeitada.
- **`CaixaHome3d` / `OptimizedEmbalagem3d`** passam a tratar 3 estados (carregando / carregado / indisponível) e exibem o componente compartilhado `WebGLFallback` no estado indisponível, em vez do spinner infinito.
- **LCP** — `priority` na imagem do logo above-the-fold (navbar desktop e mobile).

Spec e plano em `docs/superpowers/`.

## Test Plan

- [x] Suíte completa: 52 testes passam (`bun run test`)
- [ ] `bun dev` em navegador sem WebGL → terminal sem erros `WebGLRenderer`/`isPresenting`; card "Visualização 3D indisponível" visível
- [ ] `bun dev` em navegador com WebGL → modelos 3D carregam e rotacionam normalmente

> Nota: `bun run lint` falha por erro pré-existente de config (`@eslint/eslintrc` circular structure, eslint 10 + eslint-config-next) — não relacionado a esta branch.