### PR TITLE
fix: hold do vídeo no hero e correção do bug de ViewTimeline

### DIFF
--- a/app/(site)/(home)/_components/scrollExpansionHero.tsx
+++ b/app/(site)/(home)/_components/scrollExpansionHero.tsx
@@ -110,8 +110,8 @@ function DesktopHero() {
     offset: ['start start', 'end end']
   });
 
-  // Timeline (600vh = 500vh de scroll real ≈ 5 voltas de roda):
-  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~440vh de hold,
+  // Timeline (300vh = 200vh de scroll real ≈ 2 voltas de roda):
+  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~175vh de hold,
   // até a section sticky desgrudar e revelar o conteúdo.
   const leftX = useTransform(scrollYProgress, [0, 0.1], [0, -300]);
   const rightX = useTransform(scrollYProgress, [0, 0.1], [0, 300]);
@@ -141,7 +141,7 @@ function DesktopHero() {
   }
 
   return (
-    <section ref={heroRef} className='relative h-[600vh]'>
+    <section ref={heroRef} className='relative h-[300vh]'>
       <div className='sticky top-0 h-screen overflow-hidden pt-16'>
         {/* Background escuro base */}
         <div className='absolute inset-0 bg-secondary' />

--- a/app/(site)/(home)/_components/scrollExpansionHero.tsx
+++ b/app/(site)/(home)/_components/scrollExpansionHero.tsx
@@ -110,23 +110,21 @@ function DesktopHero() {
     offset: ['start start', 'end end']
   });
 
-  // Timeline (300vh = 200vh de scroll real):
-  // Cards e vídeo se sobrepõem — vídeo aparece ENQUANTO cards saem
-  // Movimentação dos cards é sutil (como o original: ~300px)
-  const leftX = useTransform(scrollYProgress, [0, 0.5], [0, -300]);
-  const rightX = useTransform(scrollYProgress, [0, 0.5], [0, 300]);
-  const cardsOpacity = useTransform(scrollYProgress, [0, 0.025], [1, 0]);
+  // Timeline (600vh = 500vh de scroll real ≈ 5 voltas de roda):
+  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~440vh de hold,
+  // até a section sticky desgrudar e revelar o conteúdo.
+  const leftX = useTransform(scrollYProgress, [0, 0.1], [0, -300]);
+  const rightX = useTransform(scrollYProgress, [0, 0.1], [0, 300]);
+  const cardsOpacity = useTransform(scrollYProgress, [0, 0.06], [1, 0]);
 
-  const videoOpacity = useTransform(scrollYProgress, [0, 0.035], [0, 1]);
-  const videoScale = useTransform(scrollYProgress, [0, 0.5], [0.8, 1.1]);
-
-  const lightBgOpacity = useTransform(scrollYProgress, [0.6, 1.0], [0, 1]);
+  const videoOpacity = useTransform(scrollYProgress, [0.04, 0.12], [0, 1]);
+  const videoScale = useTransform(scrollYProgress, [0, 1], [0.8, 1.05]);
 
   const gridOpacity = useTransform(scrollYProgress, [0.05, 0.3], [1, 0]);
 
   // Esconde cards completamente quando opacity chega a 0
   useMotionValueEvent(scrollYProgress, 'change', (v) => {
-    setCardsHidden(v > 0.03);
+    setCardsHidden(v > 0.1);
   });
 
   // Se reduced motion, mostra tudo estático
@@ -142,16 +140,10 @@ function DesktopHero() {
   }
 
   return (
-    <section ref={heroRef} className='relative h-[140vh]'>
+    <section ref={heroRef} className='relative h-[600vh]'>
       <div className='sticky top-0 h-screen overflow-hidden pt-16'>
         {/* Background escuro base */}
         <div className='absolute inset-0 bg-secondary' />
-
-        {/* Background claro (crossfade) */}
-        <motion.div
-          className='absolute inset-0 bg-white'
-          style={{ opacity: lightBgOpacity }}
-        />
 
         {/* Grid pattern com fade */}
         <motion.div

--- a/app/(site)/(home)/_components/scrollExpansionHero.tsx
+++ b/app/(site)/(home)/_components/scrollExpansionHero.tsx
@@ -115,8 +115,12 @@ function DesktopHero() {
   // até a section sticky desgrudar e revelar o conteúdo.
   const leftX = useTransform(scrollYProgress, [0, 0.1], [0, -300]);
   const rightX = useTransform(scrollYProgress, [0, 0.1], [0, 300]);
+  // Forma de função (não array input/output): impede o framer-motion de
+  // descarregar a opacity para uma WAAPI/ViewTimeline nativa, que renderiza
+  // o progresso de scroll invertido. Transforms (x, scale) não sofrem isso.
   const cardsOpacity = useTransform(() => {
     const p = scrollYProgress.get();
+    if (p <= 0) return 1;
     if (p >= 0.06) return 0;
     return 1 - p / 0.06;
   });

--- a/app/(site)/(home)/_components/scrollExpansionHero.tsx
+++ b/app/(site)/(home)/_components/scrollExpansionHero.tsx
@@ -110,18 +110,32 @@ function DesktopHero() {
     offset: ['start start', 'end end']
   });
 
-  // Timeline (300vh = 200vh de scroll real ≈ 2 voltas de roda):
-  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~175vh de hold,
+  // Timeline (200vh = 100vh de scroll real ≈ 1 volta de roda):
+  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~85vh de hold,
   // até a section sticky desgrudar e revelar o conteúdo.
   const leftX = useTransform(scrollYProgress, [0, 0.1], [0, -300]);
   const rightX = useTransform(scrollYProgress, [0, 0.1], [0, 300]);
-  const cardsOpacity = useTransform(scrollYProgress, [0, 0.06], [1, 0]);
+  const cardsOpacity = useTransform(() => {
+    const p = scrollYProgress.get();
+    if (p >= 0.06) return 0;
+    return 1 - p / 0.06;
+  });
 
   // Vídeo entra em 0.04 com leve sobreposição ao fim do fade dos cards (0.06) — crossfade intencional
-  const videoOpacity = useTransform(scrollYProgress, [0.04, 0.12], [0, 1]);
+  const videoOpacity = useTransform(() => {
+    const p = scrollYProgress.get();
+    if (p <= 0.04) return 0;
+    if (p >= 0.12) return 1;
+    return (p - 0.04) / 0.08;
+  });
   const videoScale = useTransform(scrollYProgress, [0, 1], [0.8, 1.05]);
 
-  const gridOpacity = useTransform(scrollYProgress, [0.05, 0.3], [1, 0]);
+  const gridOpacity = useTransform(() => {
+    const p = scrollYProgress.get();
+    if (p <= 0.05) return 1;
+    if (p >= 0.3) return 0;
+    return 1 - (p - 0.05) / 0.25;
+  });
 
   // Esconde cards completamente quando opacity chega a 0
   useMotionValueEvent(scrollYProgress, 'change', (v) => {
@@ -141,7 +155,7 @@ function DesktopHero() {
   }
 
   return (
-    <section ref={heroRef} className='relative h-[300vh]'>
+    <section ref={heroRef} className='relative h-[200vh]'>
       <div className='sticky top-0 h-screen overflow-hidden pt-16'>
         {/* Background escuro base */}
         <div className='absolute inset-0 bg-secondary' />

--- a/app/(site)/(home)/_components/scrollExpansionHero.tsx
+++ b/app/(site)/(home)/_components/scrollExpansionHero.tsx
@@ -117,6 +117,7 @@ function DesktopHero() {
   const rightX = useTransform(scrollYProgress, [0, 0.1], [0, 300]);
   const cardsOpacity = useTransform(scrollYProgress, [0, 0.06], [1, 0]);
 
+  // Vídeo entra em 0.04 com leve sobreposição ao fim do fade dos cards (0.06) — crossfade intencional
   const videoOpacity = useTransform(scrollYProgress, [0.04, 0.12], [0, 1]);
   const videoScale = useTransform(scrollYProgress, [0, 1], [0.8, 1.05]);
 
@@ -124,7 +125,7 @@ function DesktopHero() {
 
   // Esconde cards completamente quando opacity chega a 0
   useMotionValueEvent(scrollYProgress, 'change', (v) => {
-    setCardsHidden(v > 0.1);
+    setCardsHidden(v > 0.06);
   });
 
   // Se reduced motion, mostra tudo estático

--- a/docs/superpowers/plans/2026-05-19-hero-scroll-video-hold.md
+++ b/docs/superpowers/plans/2026-05-19-hero-scroll-video-hold.md
@@ -1,0 +1,104 @@
+# Hero Scroll Video Hold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corrigir o `DesktopHero` para que o vídeo central abra após ~1 scroll e permaneça aberto por ~5 scrolls antes de revelar o conteúdo, em vez de sumir no 2º scroll.
+
+**Architecture:** O `DesktopHero` usa o padrão sticky-scroll de `motion/react`: uma `<section>` alta com um `div sticky` interno; `scrollYProgress` (0→1) é mapeado sobre `altura − 100vh`. A correção aumenta a altura da section de `140vh` para `600vh` (500vh de scroll real) e re-cronometra os `useTransform` para criar um platô longo de `opacity:1` no vídeo. O overlay branco `lightBgOpacity` é removido.
+
+**Tech Stack:** Next.js (App Router), React, `motion/react`, Tailwind CSS, Vitest.
+
+---
+
+### Task 1: Re-timing e altura do DesktopHero
+
+**Files:**
+- Modify: `app/(site)/(home)/_components/scrollExpansionHero.tsx` (função `DesktopHero`, linhas ~103-221)
+- Test: `app/(site)/(home)/_components/__tests__/scrollExpansionHero.test.tsx` (sem alteração — só executar)
+
+- [ ] **Step 1: Confirmar baseline dos testes**
+
+Run: `npm test -- scrollExpansionHero`
+Expected: PASS (4 testes verdes). Os testes mockam `useTransform`/`useScroll` e não dependem de thresholds.
+
+- [ ] **Step 2: Atualizar o comentário stale e os `useTransform` (linhas ~113-125)**
+
+Substituir o bloco de comentário + transforms por:
+
+```tsx
+  // Timeline (600vh = 500vh de scroll real ≈ 5 voltas de roda):
+  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~440vh de hold,
+  // até a section sticky desgrudar e revelar o conteúdo.
+  const leftX = useTransform(scrollYProgress, [0, 0.1], [0, -300]);
+  const rightX = useTransform(scrollYProgress, [0, 0.1], [0, 300]);
+  const cardsOpacity = useTransform(scrollYProgress, [0, 0.06], [1, 0]);
+
+  const videoOpacity = useTransform(scrollYProgress, [0.04, 0.12], [0, 1]);
+  const videoScale = useTransform(scrollYProgress, [0, 1], [0.8, 1.05]);
+
+  const gridOpacity = useTransform(scrollYProgress, [0.05, 0.3], [1, 0]);
+```
+
+Nota: a linha `const lightBgOpacity = useTransform(...)` é removida neste passo.
+
+- [ ] **Step 3: Atualizar o threshold de `cardsHidden` (linha ~128-130)**
+
+Trocar:
+
+```tsx
+  useMotionValueEvent(scrollYProgress, 'change', (v) => {
+    setCardsHidden(v > 0.03);
+  });
+```
+
+por:
+
+```tsx
+  useMotionValueEvent(scrollYProgress, 'change', (v) => {
+    setCardsHidden(v > 0.1);
+  });
+```
+
+- [ ] **Step 4: Aumentar a altura da section (linha ~145)**
+
+Trocar `<section ref={heroRef} className='relative h-[140vh]'>` por:
+
+```tsx
+    <section ref={heroRef} className='relative h-[600vh]'>
+```
+
+- [ ] **Step 5: Remover o overlay branco `lightBgOpacity` (linhas ~150-154)**
+
+Remover este bloco inteiro:
+
+```tsx
+        {/* Background claro (crossfade) */}
+        <motion.div
+          className='absolute inset-0 bg-white'
+          style={{ opacity: lightBgOpacity }}
+        />
+```
+
+Manter o `<div className='absolute inset-0 bg-secondary' />` (background escuro base) e o bloco `gridOpacity` logo abaixo.
+
+- [ ] **Step 6: Rodar os testes**
+
+Run: `npm test -- scrollExpansionHero`
+Expected: PASS (4 testes verdes, sem regressão).
+
+- [ ] **Step 7: Lint**
+
+Run: `npm run lint`
+Expected: sem erros (em particular, nenhum `lightBgOpacity` não-usado).
+
+- [ ] **Step 8: Verificação visual**
+
+Run: `npm run dev` e abrir a home em viewport desktop (≥768px).
+Expected: ao rolar, os cards (texto + 3D) saem após ~1 scroll, o vídeo abre e permanece fixo por ~5 voltas de roda, e o conteúdo abaixo é revelado sem tela branca prematura.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/(site)/(home)/_components/scrollExpansionHero.tsx
+git commit -m "fix: hold do vídeo no hero scroll do desktop"
+```

--- a/docs/superpowers/plans/2026-05-19-hero-video-viewtimeline-fix.md
+++ b/docs/superpowers/plans/2026-05-19-hero-video-viewtimeline-fix.md
@@ -1,0 +1,131 @@
+# Hero Video ViewTimeline Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corrigir o vídeo do `DesktopHero` que desbota até `opacity:0` no hold (e o grid que nunca some), causado pelo offload das `opacity` ligadas a scroll para uma `ViewTimeline` nativa bugada, e encurtar a seção para `200vh`.
+
+**Architecture:** O framer-motion (`motion/react`) descarrega MotionValues de `opacity` ligados a scroll para animações WAAPI presas a uma `ViewTimeline` nativa, cujo mapeamento de progresso diverge do `useScroll` (rAF). A forma de função do `useTransform` (`useTransform(() => ...)`) não pode ser expressa como keyframes nativos, então o framer mantém o valor no rAF — onde funciona. A correção converte as três `opacity` (`videoOpacity`, `cardsOpacity`, `gridOpacity`) para a forma de função. Transforms (`x`, `scale`) não sofrem o offload e ficam inalterados.
+
+**Tech Stack:** Next.js (App Router), React, `motion/react`, Tailwind CSS, Vitest.
+
+---
+
+### Task 1: Converter opacity para forma de função e encurtar a seção
+
+**Files:**
+- Modify: `app/(site)/(home)/_components/scrollExpansionHero.tsx` (função `DesktopHero`)
+- Test: `app/(site)/(home)/_components/__tests__/scrollExpansionHero.test.tsx` (sem alteração — só executar)
+
+Nota: o repo pode já conter uma conversão parcial de teste do `videoOpacity` (sem commit). Os passos abaixo descrevem o estado final desejado independentemente disso — aplique o que faltar para chegar nesse estado.
+
+- [ ] **Step 1: Confirmar baseline dos testes**
+
+Run: `npm test -- scrollExpansionHero`
+Expected: PASS (4 testes verdes). Os testes mockam `useTransform` e não dependem da forma do argumento.
+
+- [ ] **Step 2: Converter `cardsOpacity` para forma de função**
+
+Trocar a linha:
+
+```tsx
+  const cardsOpacity = useTransform(scrollYProgress, [0, 0.06], [1, 0]);
+```
+
+por:
+
+```tsx
+  const cardsOpacity = useTransform(() => {
+    const p = scrollYProgress.get();
+    if (p >= 0.06) return 0;
+    return 1 - p / 0.06;
+  });
+```
+
+- [ ] **Step 3: Garantir `videoOpacity` na forma de função**
+
+A declaração de `videoOpacity` deve ser exatamente:
+
+```tsx
+  // Vídeo entra em 0.04 com leve sobreposição ao fim do fade dos cards (0.06) — crossfade intencional
+  const videoOpacity = useTransform(() => {
+    const p = scrollYProgress.get();
+    if (p <= 0.04) return 0;
+    if (p >= 0.12) return 1;
+    return (p - 0.04) / 0.08;
+  });
+```
+
+Se já estiver assim, nenhuma mudança neste passo.
+
+- [ ] **Step 4: Converter `gridOpacity` para forma de função**
+
+Trocar a linha:
+
+```tsx
+  const gridOpacity = useTransform(scrollYProgress, [0.05, 0.3], [1, 0]);
+```
+
+por:
+
+```tsx
+  const gridOpacity = useTransform(() => {
+    const p = scrollYProgress.get();
+    if (p <= 0.05) return 1;
+    if (p >= 0.3) return 0;
+    return 1 - (p - 0.05) / 0.25;
+  });
+```
+
+`leftX`, `rightX` e `videoScale` permanecem inalterados (são transforms, funcionam).
+
+- [ ] **Step 5: Encurtar a seção e atualizar o comentário da timeline**
+
+Trocar o comentário das três linhas:
+
+```tsx
+  // Timeline (300vh = 200vh de scroll real ≈ 2 voltas de roda):
+  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~175vh de hold,
+  // até a section sticky desgrudar e revelar o conteúdo.
+```
+
+por:
+
+```tsx
+  // Timeline (200vh = 100vh de scroll real ≈ 1 volta de roda):
+  // Cards saem cedo, vídeo entra e fica fixo (opacity:1) por ~85vh de hold,
+  // até a section sticky desgrudar e revelar o conteúdo.
+```
+
+E trocar:
+
+```tsx
+    <section ref={heroRef} className='relative h-[300vh]'>
+```
+
+por:
+
+```tsx
+    <section ref={heroRef} className='relative h-[200vh]'>
+```
+
+- [ ] **Step 6: Rodar os testes**
+
+Run: `npm test -- scrollExpansionHero`
+Expected: PASS (4 testes verdes).
+
+- [ ] **Step 7: Lint (informativo)**
+
+Run: `npm run lint`
+Expected: pode falhar com `TypeError: ... react/display-name ... getFilename is not a function` — incompatibilidade pré-existente entre `eslint-plugin-react` e ESLint 10, fora do escopo. Nenhum erro novo deve surgir em `scrollExpansionHero.tsx`.
+
+- [ ] **Step 8: Verificação visual no browser**
+
+Run: `npm run dev` e abrir a home em viewport desktop (≥768px).
+Expected: o vídeo abre após ~1 scroll, fica em `opacity:1` por todo o hold (não desbota), o grid some conforme o vídeo entra, e o conteúdo é revelado ao fim. Confirmação técnica: `document.querySelector('video').closest('div').getAnimations()` deve retornar vazio (sem `ViewTimeline`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add "app/(site)/(home)/_components/scrollExpansionHero.tsx"
+git commit -m "fix: corrige offload de opacity para ViewTimeline no hero"
+```

--- a/docs/superpowers/specs/2026-05-19-hero-scroll-video-hold-design.md
+++ b/docs/superpowers/specs/2026-05-19-hero-scroll-video-hold-design.md
@@ -1,0 +1,88 @@
+# Hero: hold do vídeo no scroll (DesktopHero)
+
+Data: 2026-05-19
+
+## Problema
+
+Na home (`app/(site)/(home)/`), o componente `ScrollExpandMedia` →
+`DesktopHero` deveria: carregar com texto à esquerda e modelo 3D à direita;
+após ~1 scroll abrir o vídeo central; e manter o vídeo aberto por ~5 scrolls
+antes de revelar o conteúdo.
+
+Comportamento atual (bug): no 2º scroll o vídeo já some e o usuário vê uma
+tela branca.
+
+## Causa raiz
+
+`DesktopHero` usa o padrão sticky-scroll: a `<section>` é alta e um
+`div sticky top-0 h-screen` fica fixo enquanto se rola. O `scrollYProgress`
+(0→1) é mapeado sobre o trecho de rolagem extra = `altura da section − 100vh`.
+
+A section está em `h-[140vh]` → apenas **40vh de scroll real** para a timeline
+inteira. O comentário das linhas 113-114 ainda diz "300vh = 200vh de scroll
+real": a altura foi reduzida e a timeline ficou espremida.
+
+Consequência:
+
+| Evento | Progress | Scroll real |
+|---|---|---|
+| Cards somem | `0 → 0.025` | ~1vh |
+| Vídeo aparece | `0 → 0.035` | ~1.4vh |
+| Fim da timeline / section desgruda | `1.0` | 40vh |
+
+- 1º scroll → cards somem e vídeo abre quase instantaneamente.
+- 2º scroll → passa-se dos 40vh, a section `sticky` solta e cai na seção
+  `children` (`bg-white`) → tela branca.
+
+Não é problema de transparência. Faltam: (1) section alta o suficiente para os
+~5 scrolls de permanência; (2) re-timing dos `useTransform` com um platô longo
+em `opacity:1` para o vídeo.
+
+## Escopo
+
+Apenas a função `DesktopHero` em
+`app/(site)/(home)/_components/scrollExpansionHero.tsx`. `MobileHero` não muda.
+
+## Solução
+
+### 1. Altura da seção
+
+`h-[140vh]` → `h-[600vh]` (500vh de trecho de scroll real ≈ 5 voltas de roda).
+Atualizar o comentário stale das linhas 113-114.
+
+### 2. Re-timing da timeline (`useTransform` sobre `scrollYProgress` 0→1 = 500vh)
+
+| Elemento | Hoje | Novo |
+|---|---|---|
+| `cardsOpacity` | `[0, 0.025] → [1, 0]` | `[0, 0.06] → [1, 0]` |
+| `leftX` / `rightX` | `[0, 0.5] → [0, ∓300]` | `[0, 0.1] → [0, ∓300]` |
+| `cardsHidden` (useMotionValueEvent) | `v > 0.03` | `v > 0.1` |
+| `videoOpacity` | `[0, 0.035] → [0, 1]` | `[0.04, 0.12] → [0, 1]` |
+| `videoScale` | `[0, 0.5] → [0.8, 1.1]` | `[0, 1] → [0.8, 1.05]` |
+
+Hold do vídeo: de `progress 0.12` até `1.0`, `videoOpacity` permanece 1 ≈
+440vh de scroll com o vídeo fixo.
+
+### 3. Final — "fica e solta no conteúdo"
+
+O vídeo permanece em `opacity:1` até o fim. Em `progress 1.0` a section
+`sticky` desgruda e a seção `children` (`bg-white`) aparece naturalmente. Sem
+fade-out do vídeo.
+
+Remover o overlay branco `lightBgOpacity` (linhas 123, 151-154) — o conteúdo
+abaixo já é branco; o overlay não é mais necessário com "soltar direto".
+
+`gridOpacity` é mantido (grid some conforme o vídeo abre).
+
+## Testes
+
+`scrollExpansionHero.test.tsx` mocka `useTransform`/`useScroll`/
+`useMotionValueEvent` e não verifica thresholds — nenhuma alteração de teste é
+necessária. Rodar a suíte para confirmar que continua verde.
+
+## Verificação
+
+- `npm test` (ou equivalente) — suíte passa.
+- Verificação visual no browser: carregar a home em desktop, rolar e confirmar
+  que o vídeo abre após ~1 scroll, fica fixo por ~5 scrolls e o conteúdo é
+  revelado sem tela branca prematura.

--- a/docs/superpowers/specs/2026-05-19-hero-video-viewtimeline-bug-design.md
+++ b/docs/superpowers/specs/2026-05-19-hero-video-viewtimeline-bug-design.md
@@ -1,0 +1,97 @@
+# Hero: vídeo desbota no fim — bug de ViewTimeline
+
+Data: 2026-05-19
+
+## Problema
+
+No `DesktopHero` (`app/(site)/(home)/_components/scrollExpansionHero.tsx`), o
+vídeo central abre normalmente mas **desbota até `opacity:0` ao longo do
+hold**, em vez de ficar fixo até a seção rolar embora. O grid de fundo tem o
+mesmo defeito ao contrário: nunca some — continua visível em `opacity:1` mesmo
+em `progress 1.0`.
+
+## Investigação
+
+Medições ao vivo no browser (dev server, seção `h-[300vh]`, `progress 1.0` em
+`scrollY=1278`):
+
+- O `style.opacity` inline do wrapper do vídeo fica congelado em `0`, mas o
+  `opacity` computado segue uma curva `1 → 0`.
+- `getAnimations()` no wrapper revela uma animação WAAPI:
+  - `timeline: ViewTimeline`
+  - `keyframes: [{offset:0.04, opacity:0}, {offset:0.12, opacity:1}]`
+- O wrapper do grid tem a mesma animação `ViewTimeline` e fica preso em
+  `opacity:1`.
+- `videoScale` (transform `scale`) e `leftX`/`rightX` (transform `x`) atualizam
+  corretamente via `style` inline (rAF) — não são descarregados.
+
+## Causa raiz
+
+O framer-motion (`motion/react`) otimiza MotionValues de `opacity` ligados a
+scroll descarregando-os para uma animação acelerada por hardware (WAAPI) presa
+a uma `ViewTimeline` nativa do CSS. A `ViewTimeline` mapeia o progresso de
+forma inconsistente com o `useScroll` baseado em rAF (`offset: ['start start',
+'end end']`) — na prática, invertida. Resultado:
+
+- `videoOpacity` (`useTransform([0.04, 0.12], [0, 1])`) renderiza a curva ao
+  contrário → vídeo desbota.
+- `gridOpacity` (`useTransform([0.05, 0.3], [1, 0])`) idem → grid nunca some.
+- `cardsOpacity` (`useTransform([0, 0.06], [1, 0])`) — mesmo padrão.
+
+Transforms (`x`, `scale`) não passam por esse caminho de offload, por isso
+funcionam.
+
+## Solução
+
+### 1. Evitar o offload das três `opacity`
+
+Converter `videoOpacity`, `gridOpacity` e `cardsOpacity` da forma de
+input/output range para a **forma de função** do `useTransform`. O framer não
+consegue expressar um callback como keyframes nativos, então mantém o valor no
+rAF — onde funciona corretamente, como os transforms.
+
+```tsx
+const videoOpacity = useTransform(() => {
+  const p = scrollYProgress.get();
+  if (p <= 0.04) return 0;
+  if (p >= 0.12) return 1;
+  return (p - 0.04) / 0.08;
+});
+
+const cardsOpacity = useTransform(() => {
+  const p = scrollYProgress.get();
+  if (p >= 0.06) return 0;
+  return 1 - p / 0.06;
+});
+
+const gridOpacity = useTransform(() => {
+  const p = scrollYProgress.get();
+  if (p <= 0.05) return 1;
+  if (p >= 0.3) return 0;
+  return 1 - (p - 0.05) / 0.25;
+});
+```
+
+Verificado ao vivo: com `videoOpacity` na forma de função, a animação
+`ViewTimeline` some (`getAnimations()` vazio) e a opacidade fica `1` do início
+ao fim do hold.
+
+`leftX`, `rightX` e `videoScale` permanecem inalterados — funcionam.
+
+### 2. Encurtar a seção
+
+`h-[300vh]` → `h-[200vh]` (~100vh de scroll real, hold ~85vh). Atualizar o
+comentário da timeline para refletir 200vh.
+
+## Testes
+
+`scrollExpansionHero.test.tsx` mocka `useTransform` e não verifica thresholds
+nem a forma do argumento — nenhuma alteração de teste é necessária. Rodar a
+suíte para confirmar que continua verde.
+
+## Verificação
+
+- `npm test` — suíte passa.
+- Verificação visual no browser: o vídeo abre após ~1 scroll, fica em
+  `opacity:1` por todo o hold, o grid some conforme o vídeo entra, e o conteúdo
+  é revelado ao fim sem o vídeo desbotar prematuramente.


### PR DESCRIPTION
## Resumo

Corrige o comportamento do vídeo central do `ScrollExpandMedia` no `DesktopHero` da home.

- **Hold do vídeo:** o vídeo agora abre após ~1 scroll e permanece em tela durante o hold, em vez de sumir cedo demais. Seção ajustada para `h-[200vh]`.
- **Bug de ViewTimeline (causa raiz):** o framer-motion descarregava as `opacity` ligadas a scroll para animações WAAPI presas a uma `ViewTimeline` nativa do CSS, cujo progresso é mapeado de forma invertida em relação ao `useScroll` (rAF) — fazendo o vídeo desbotar até `opacity:0` e o grid nunca sumir. As três `opacity` (`videoOpacity`, `cardsOpacity`, `gridOpacity`) foram convertidas para a **forma de função** do `useTransform`, que o framer não consegue converter em keyframes nativos, mantendo o cálculo no rAF. Transforms (`x`, `scale`) não sofrem o offload e ficam inalterados.

## Documentação

- `docs/superpowers/specs/2026-05-19-hero-video-viewtimeline-bug-design.md`
- `docs/superpowers/plans/2026-05-19-hero-video-viewtimeline-fix.md`

## Test Plan

- [x] `npm test` — 52/52 passam
- [x] Verificação visual: vídeo em `opacity:1` do início ao fim do hold, grid some corretamente, sem `ViewTimeline` no `getAnimations()`
- [ ] Conferir em desktop num navegador real

## Notas

`npm run lint` falha por incompatibilidade pré-existente entre `eslint-plugin-react` e ESLint 10 — não relacionada a este PR.