### PR TITLE
fix: mantém grid sempre visível atrás do vídeo no hero

### DIFF
--- a/app/(site)/(home)/_components/scrollExpansionHero.tsx
+++ b/app/(site)/(home)/_components/scrollExpansionHero.tsx
@@ -134,13 +134,6 @@ function DesktopHero() {
   });
   const videoScale = useTransform(scrollYProgress, [0, 1], [0.8, 1.05]);
 
-  const gridOpacity = useTransform(() => {
-    const p = scrollYProgress.get();
-    if (p <= 0.05) return 1;
-    if (p >= 0.3) return 0;
-    return 1 - (p - 0.05) / 0.25;
-  });
-
   // Esconde cards completamente quando opacity chega a 0
   useMotionValueEvent(scrollYProgress, 'change', (v) => {
     setCardsHidden(v > 0.06);
@@ -164,12 +157,10 @@ function DesktopHero() {
         {/* Background escuro base */}
         <div className='absolute inset-0 bg-secondary' />
 
-        {/* Grid pattern com fade */}
-        <motion.div
-          className='absolute inset-0'
-          style={{ opacity: gridOpacity }}>
+        {/* Grid pattern — sempre visível, mantém o padrão da seção atrás do vídeo */}
+        <div className='absolute inset-0'>
           <GridPattern />
-        </motion.div>
+        </div>
 
         {/* Layout principal */}
         <div className='relative z-10 flex h-full w-full items-center justify-center'>


### PR DESCRIPTION
## Problema

Depois do PR #15 corrigir o bug de `ViewTimeline`, o `gridOpacity` passou a funcionar como originalmente programado — fazer o grid sumir conforme o vídeo entra (chega a `opacity:0` em progress 0.3). Como o vídeo do hero não cobre a tela toda (`object-cover max-h-[65vh] max-w-[70vw]`), em volta dele ficava o `bg-secondary` azul sólido em vez do padrão de grid da seção.

Antes, o bug travava o grid em `opacity:1` permanente — então ninguém percebia a intenção original de apagá-lo. Com o fade funcionando, a intenção original ficou visualmente errada.

## Solução

Remover o `gridOpacity` e seu binding. O `<GridPattern />` agora fica em um `<div>` simples com `opacity:1` permanente, mantendo o padrão visual da seção atrás e em volta do vídeo durante todo o hold.

## Test Plan

- [x] `npm test` — 4/4 passam em `scrollExpansionHero`
- [x] `npx prettier --check` — formatado
- [ ] Conferir visualmente em desktop: o grid deve aparecer durante todo o hold do vídeo, sem azul sólido em volta