### PR TITLE
feat: WhatsApp direto no footer, sem telefone visível

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -10,8 +10,18 @@ import logoProfills from '@/public/logo-branco.png';
 import logoCartoonsRanca from '@/public/profills-cartoons-ranca.png';
 
 import { GridPattern } from './gridPatternBg';
-import { socialLinks } from './socialLinks';
+import { WhatsAppIcon, socialLinks } from './socialLinks';
 import { Mail, MapPin, Phone } from 'lucide-react';
+
+// Números por setor (só nos links wa.me — nunca renderizados na tela).
+// TODO: trocar Suporte e Compras quando o comercial confirmar os números.
+const WHATSAPP_VENDAS = '5541997851998';
+const WHATSAPP_SUPORTE = '5541997851998';
+const WHATSAPP_COMPRAS = '5541997851998';
+
+function waLink(numero: string, mensagem: string) {
+  return `https://wa.me/${numero}?text=${encodeURIComponent(mensagem)}`;
+}
 
 const contacts = [
   {
@@ -24,9 +34,14 @@ const contacts = [
         label: 'comercial@profillsdobrasil.com.br'
       },
       {
-        href: 'tel:+5541997851998',
-        icon: Phone,
-        label: '+55 (41) 99785-1998'
+        href: waLink(
+          WHATSAPP_VENDAS,
+          'Olá! Vim pelo site da Profills e quero falar com Vendas/Peças.'
+        ),
+        icon: WhatsAppIcon,
+        label: 'Conversar no WhatsApp',
+        ariaLabel: 'Conversar no WhatsApp com Vendas/Peças',
+        external: true
       }
     ]
   },
@@ -38,6 +53,16 @@ const contacts = [
         href: 'mailto:suporte@profillsdobrasil.com.br',
         icon: Mail,
         label: 'suporte@profillsdobrasil.com.br'
+      },
+      {
+        href: waLink(
+          WHATSAPP_SUPORTE,
+          'Olá! Vim pelo site da Profills e preciso de suporte técnico.'
+        ),
+        icon: WhatsAppIcon,
+        label: 'Conversar no WhatsApp',
+        ariaLabel: 'Conversar no WhatsApp com Suporte e Assistência Técnica',
+        external: true
       }
     ]
   },
@@ -51,9 +76,14 @@ const contacts = [
         label: 'compras@profillsdobrasil.com.br'
       },
       {
-        href: 'tel:+554197695013',
-        icon: Phone,
-        label: '+55 (41) 9769-5013'
+        href: waLink(
+          WHATSAPP_COMPRAS,
+          'Olá! Vim pelo site da Profills e quero falar com Compras.'
+        ),
+        icon: WhatsAppIcon,
+        label: 'Conversar no WhatsApp',
+        ariaLabel: 'Conversar no WhatsApp com Compras (Fornecedores)',
+        external: true
       }
     ]
   }
@@ -90,7 +120,7 @@ export default function Footer() {
 
   return (
     <footer className='relative overflow-hidden bg-secondary'>
-      <GridPattern />
+      <GridPattern className='[mask-image:linear-gradient(to_bottom,transparent_0,black_80px,black_100%)]' />
 
       <div className='relative mx-auto max-w-7xl px-4 py-8 md:px-6 md:pt-14 md:pb-10'>
         <BlurFade delay={0.1} inView>
@@ -137,17 +167,24 @@ export default function Footer() {
                   </h3>
                 </div>
                 <div className='flex flex-col space-y-2 md:space-y-3'>
-                  {contact.links.map(({ href, icon: LinkIcon, label }) => (
-                    <Link
-                      key={href}
-                      href={href}
-                      className='group/link flex items-center gap-2 text-secondary-foreground/60 transition-colors hover:text-accent md:gap-3'>
-                      <LinkIcon className='h-4 w-4 text-accent/60 transition-colors group-hover/link:text-accent md:h-4 md:w-4' />
-                      <span className='text-xs font-medium md:text-sm'>
-                        {label}
-                      </span>
-                    </Link>
-                  ))}
+                  {contact.links.map(
+                    ({ href, icon: LinkIcon, label, ariaLabel, external }) => (
+                      <Link
+                        key={href}
+                        href={href}
+                        aria-label={ariaLabel}
+                        {...(external && {
+                          target: '_blank',
+                          rel: 'noopener noreferrer'
+                        })}
+                        className='group/link flex items-center gap-2 text-secondary-foreground/60 transition-colors hover:text-accent md:gap-3'>
+                        <LinkIcon className='h-4 w-4 text-accent/60 transition-colors group-hover/link:text-accent md:h-4 md:w-4' />
+                        <span className='text-xs font-medium md:text-sm'>
+                          {label}
+                        </span>
+                      </Link>
+                    )
+                  )}
                 </div>
               </div>
             </BlurFade>

--- a/components/layout/socialLinks.tsx
+++ b/components/layout/socialLinks.tsx
@@ -8,6 +8,14 @@ export type SocialLink = {
   Icon: ComponentType<SocialIconProps>;
 };
 
+export function WhatsAppIcon(props: SocialIconProps) {
+  return (
+    <svg viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' {...props}>
+      <path d='M12.04 2C6.58 2 2.13 6.45 2.13 11.91c0 1.75.46 3.45 1.32 4.95L2 22l5.25-1.38a9.9 9.9 0 0 0 4.79 1.22h.01c5.46 0 9.91-4.45 9.91-9.91 0-2.65-1.03-5.14-2.9-7.01A9.82 9.82 0 0 0 12.04 2Zm5.8 14.15c-.25.69-1.44 1.32-1.99 1.36-.53.05-.53.42-3.34-.83-2.8-1.25-4.5-4.19-4.63-4.38-.13-.19-1.09-1.55-1.03-2.9.06-1.36.79-2 1.06-2.27.27-.27.58-.33.77-.33h.55c.18 0 .42-.07.65.53.25.65.83 2.24.9 2.4.07.16.11.35.01.55-.1.2-.15.32-.3.5-.15.17-.31.39-.44.52-.15.15-.3.31-.13.6.17.29.76 1.29 1.63 2.09 1.12 1.03 2.06 1.35 2.35 1.5.29.15.46.13.63-.08.17-.2.73-.86.92-1.16.2-.29.39-.24.66-.14.27.1 1.71.81 2 .96.29.15.49.22.56.34.07.12.07.7-.18 1.39Z' />
+    </svg>
+  );
+}
+
 export function FacebookIcon(props: SocialIconProps) {
   return (
     <svg viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' {...props}>
@@ -18,11 +26,7 @@ export function FacebookIcon(props: SocialIconProps) {
 
 export function InstagramIcon(props: SocialIconProps) {
   return (
-    <svg
-      viewBox='0 0 24 24'
-      fill='currentColor'
-      aria-hidden='true'
-      {...props}>
+    <svg viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' {...props}>
       <path
         fillRule='evenodd'
         clipRule='evenodd'
@@ -42,11 +46,7 @@ export function LinkedInIcon(props: SocialIconProps) {
 
 export function YouTubeIcon(props: SocialIconProps) {
   return (
-    <svg
-      viewBox='0 0 24 24'
-      fill='currentColor'
-      aria-hidden='true'
-      {...props}>
+    <svg viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' {...props}>
       <path
         fillRule='evenodd'
         clipRule='evenodd'
@@ -60,21 +60,21 @@ export const socialLinks: SocialLink[] = [
   {
     href: 'https://www.facebook.com/profillsbrasil/',
     label: 'Facebook',
-    Icon: FacebookIcon,
+    Icon: FacebookIcon
   },
   {
     href: 'https://www.instagram.com/profillsdobrasil/',
     label: 'Instagram',
-    Icon: InstagramIcon,
+    Icon: InstagramIcon
   },
   {
     href: 'https://www.linkedin.com/company/profillsdobrasil/',
     label: 'LinkedIn',
-    Icon: LinkedInIcon,
+    Icon: LinkedInIcon
   },
   {
     href: 'https://www.youtube.com/channel/UCQhaNOzqbkYnZlknSd79zEw',
     label: 'YouTube',
-    Icon: YouTubeIcon,
-  },
+    Icon: YouTubeIcon
+  }
 ];

--- a/docs/superpowers/specs/2026-07-28-footer-whatsapp-design.md
+++ b/docs/superpowers/specs/2026-07-28-footer-whatsapp-design.md
@@ -1,0 +1,74 @@
+# Footer — WhatsApp direto sem número visível
+
+**Data:** 2026-07-28 · **Status:** aprovado (mockup validado no visual companion, desktop + mobile 390px)
+
+## Decisão
+
+Manter o footer atual **exatamente como está** (estrutura, grid, logos, BlurFade,
+copiar CNPJ) e mudar apenas o bloco de contatos + 4 melhorias pontuais aprovadas.
+Redesigns foram apresentados e descartados pelo usuário.
+
+## O que muda
+
+### 1. Contatos (`contacts` em `components/layout/footer.tsx`)
+
+- **Nenhum número de telefone visível.** As linhas `tel:` somem.
+- Cada um dos 3 setores ganha uma linha **"Conversar no WhatsApp"** no mesmo
+  estilo visual das linhas de e-mail (ícone + texto, `text-xs md:text-sm`),
+  inclusive **Suporte**, que hoje só tem e-mail — de quebra os 3 cards ficam da
+  mesma altura (some o buraco do card do meio).
+- Link: `https://wa.me/<NUMERO>?text=<MENSAGEM>` com mensagem pré-preenchida por
+  setor, ex.: `Olá! Vim pelo site da Profills e quero falar com Vendas/Peças.`
+- Números por setor em constantes no topo do arquivo (padrão já usado em
+  `app/(standalone)/sorteio-fispal-2026/page.tsx`).
+
+| Setor | Número | Mensagem pré-preenchida |
+| --- | --- | --- |
+| Vendas/Peças | **A CONFIRMAR** | Olá! Vim pelo site da Profills e quero falar com Vendas/Peças. |
+| Suporte e Assistência Técnica | **A CONFIRMAR** | Olá! Vim pelo site da Profills e preciso de suporte técnico. |
+| Compras (Fornecedores) | **A CONFIRMAR** | Olá! Vim pelo site da Profills e quero falar com Compras. |
+
+### 2. Fade do grid no topo (1 linha)
+
+`<GridPattern />` do footer ganha
+`className='[mask-image:linear-gradient(to_bottom,transparent_0,black_80px,black_100%)]'`
+— mesmo padrão já aplicado em `/sorteio-fispal-2026` (commit `c88841d`). Elimina
+a emenda seca do grid contra a seção clara acima.
+
+### 3. Link do Pro-Fills Cartons (1 linha)
+
+`href='#'` (morto) → URL real do site Cartons. **URL A CONFIRMAR** (domínio
+`profillscartons.com` existe mas pode ainda não estar anexado ao projeto Vercel —
+verificar antes de apontar). `target='_blank' rel='noopener noreferrer'`.
+
+### 4. Acessibilidade dos links de WhatsApp
+
+Três links com texto idêntico são ambíguos pra leitor de tela:
+- `aria-label='Conversar no WhatsApp com <setor>'` em cada um;
+- `target='_blank' rel='noopener noreferrer'` (wa.me é externo).
+
+### Ícone novo
+
+`WhatsAppIcon` custom (path SVG `fill='currentColor'`), no mesmo padrão dos
+ícones de `components/layout/socialLinks.tsx` — lucide ^1.16 não tem ícones de
+marca. Atenção ao teste `components/layout/lucide-social-regression.test.ts` ao
+adicionar.
+
+## O que NÃO muda
+
+- Estrutura/ordem das seções, logo, manifesto, divisor Cartons, bloco social,
+  copyright + copiar CNPJ, animações BlurFade, responsividade existente.
+- Ícones dos cabeçalhos dos cards (Phone/Mail/MapPin) — melhoria sugerida e
+  **adiada** por decisão do usuário (reavaliar com o footer no ar).
+- Navegação (sitemap) e endereço no footer — explorados no brainstorm e
+  **descartados** nesta rodada.
+
+## Verificação de pronto
+
+1. **Funcional:** clique em cada linha WhatsApp abre `wa.me` do setor certo com a
+   mensagem pré-preenchida; nenhum dígito de telefone renderizado no footer
+   (grep no HTML renderizado).
+2. **Perceptual:** screenshot desktop + mobile lado a lado com o mockup aprovado
+   (`.superpowers/brainstorm/492668-1785254136/content/footer-real*.html`);
+   cards com alturas iguais; fade do grid visível na emenda.
+3. **Dados:** os 3 números conferidos com o usuário antes do commit.


### PR DESCRIPTION
## O que muda

- **Nenhum número de telefone visível no footer.** As linhas `tel:` dos cards Vendas/Peças e Compras foram removidas.
- Cada um dos 3 setores (incluindo Suporte, que só tinha e-mail) ganha a linha **"Conversar no WhatsApp"** no mesmo estilo das linhas de e-mail — o clique abre `wa.me` direto na conversa, com mensagem pré-preenchida identificando o setor. De quebra, os 3 cards ficam com a mesma altura.
- **Fade do grid no topo** do footer (`mask-image`), mesmo padrão já usado em `/sorteio-fispal-2026` — elimina a emenda seca contra a seção clara.
- Acessibilidade: `aria-label` distinto por setor nos 3 links (antes seriam 3 links de texto idêntico) + `target=_blank rel=noopener`.
- Ícone `WhatsAppIcon` custom em `socialLinks.tsx`, no padrão dos demais ícones de marca (lucide ^1.16 não tem brand icons).

Spec completo em `docs/superpowers/specs/2026-07-28-footer-whatsapp-design.md` (mockup validado no visual companion, desktop + mobile).

## Pendências conscientes

- **Números de Suporte e Compras**: os 3 links usam por ora o número público de Vendas (`41 99785-1998`) — a mensagem pré-preenchida já faz a triagem por setor. `TODO` marcado nas constantes `WHATSAPP_SUPORTE`/`WHATSAPP_COMPRAS`; trocar é editar 2 linhas.
- **Link do Pro-Fills Cartons** segue `#`: os domínios ainda não respondem (verificado via curl), apontar agora seria trocar um link morto por outro.

## Verificação

- 52/52 testes (`vitest run`), incluindo o de regressão dos ícones sociais; `tsc --noEmit` sem erros novos.
- Grep no HTML renderizado: zero telefone formatado, zero `href="tel:"`, 3 links `wa.me` corretos.
- Medição via DOM: cards com 158px iguais; `mask-image` do grid aplicada.
- Screenshot lado a lado com o footer anterior conferido no browser real.