### PR TITLE
feat: drawer mobile ocupa 92% da tela

### DIFF
--- a/components/layout/navbarDesktop.tsx
+++ b/components/layout/navbarDesktop.tsx
@@ -136,7 +136,7 @@ export default function NavbarDesktop() {
         <div className='flex h-full w-full items-center justify-center gap-2'>
           <NavigationMenuItem>
             <NavigationMenuLink asChild>
-              <Link href='/'>Inicio</Link>
+              <Link href='/'>Início</Link>
             </NavigationMenuLink>
           </NavigationMenuItem>
           <NavigationMenuItem>

--- a/components/layout/navbarMobile.tsx
+++ b/components/layout/navbarMobile.tsx
@@ -14,6 +14,7 @@ import {
   Drawer,
   DrawerClose,
   DrawerContent,
+  DrawerDescription,
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
@@ -191,7 +192,7 @@ export default function NavbarMobile() {
               <Menu className='h-6 w-6' />
             </button>
           </DrawerTrigger>
-          <DrawerContent className='h-full w-80 border-l border-secondary-foreground/10 bg-secondary'>
+          <DrawerContent className='h-full border-l border-secondary-foreground/10 bg-secondary data-[vaul-drawer-direction=right]:w-[92%] data-[vaul-drawer-direction=right]:sm:max-w-none'>
             <DrawerHeader className='border-b border-secondary-foreground/10 pb-4'>
               <DrawerTitle className='flex items-center justify-center text-xl font-bold text-secondary-foreground'>
                 <Image
@@ -200,6 +201,9 @@ export default function NavbarMobile() {
                   className='h-8 w-auto object-contain'
                 />
               </DrawerTitle>
+              <DrawerDescription className='sr-only'>
+                Navegue pelas seções do site Profills Brasil
+              </DrawerDescription>
             </DrawerHeader>
 
             <div className='flex-1 overflow-y-auto p-4'>
@@ -211,7 +215,7 @@ export default function NavbarMobile() {
                       href='/'
                       className='hover:text-accent flex min-h-[44px] items-center border-l-2 border-transparent py-3 text-secondary-foreground transition-all duration-200 hover:border-accent hover:pl-1'>
                       <Home className='text-accent mr-2 size-5' />
-                      Home
+                      Início
                     </Link>
                   </DrawerClose>
                 </BlurFade>


### PR DESCRIPTION
## Contexto

O drawer de navegação mobile tinha largura `w-80` — 320px **fixos**. O problema não era só ser estreito, era não escalar: em tela de 320px cobria 100% sem sobra nenhuma, e em 430px caía para 74%.

## O que muda

**Largura → 92% proporcional**, com um sliver do site visível à esquerda que sinaliza que dá para tocar fora e fechar.

A sobreposição usa o mesmo modificador `data-[vaul-drawer-direction=right]` do `ui/drawer.tsx` base, de propósito: sem ele o `tailwind-merge` trata as classes como grupos distintos e não funde, deixando o `w-3/4` e o `sm:max-w-sm` do base vencerem na cascata — este último travava a largura em 384px na faixa de 640–767px. O `ui/drawer.tsx` ficou intocado.

**Descrição acessível** — `DrawerDescription` com `sr-only`. Resolve o warning do Radix que aparece no console em dev (`Missing Description or aria-describedby for DialogContent`, já que o vaul usa Radix Dialog por baixo) e faz o leitor de tela anunciar o propósito do menu.

**Rótulo padronizado em "Início"** — desktop dizia "Inicio" (sem acento) e mobile dizia "Home".

## Verificação

Medido com o drawer real renderizado:

| viewport | largura | sobra | % | max-width |
|---|---|---|---|---|
| 320px | 294px | 26px | 92,0% | none |
| 390px | 359px | 31px | 92,0% | none |
| 700px | 644px | — | 92,0% | none |
| 767px | 706px | — | 92,0% | none |

Os valores de 700 e 767 são a prova de que a sobreposição pegou: antes, o `sm:max-w-sm` travava ambos em 384px.

Suíte de testes: 52 testes em 11 arquivos, todos passando.

**Ressalva de método:** 700 e 767 foram medidos em iframe, porque o WM local (Hyprland, janela tiled) recusa os pedidos de resize do Chrome acima de ~412px. Nesses dois casos a *posição* final não assentou no iframe — artefato do iframe estar fora da tela; a largura, que é o que a mudança afeta, é confiável. Nas viewports reais a posição mediu corretamente (`left: 28px`).

## Notas de ambiente (pré-existentes, não introduzidas aqui)

Confirmados com este diff em stash:

- `tsc --noEmit` acusa um erro em `components/modelo3d/hooks/webglSupport.test.ts` (`WebGL2RenderingContext` não atribuível a `GPUCanvasContext`).
- ESLint 10.4 quebra ao carregar `eslint-plugin-react` (`getFilename is not a function`) — falha idêntica em arquivo intocado. Consequência: **esta mudança não passou por linter.**

## Achados da navbar não incluídos neste PR

Levantados na auditoria de rotas, deixados fora de propósito para manter o escopo:

- `/maquinas` sem filtro não é alcançável pela navbar — o trigger "Máquinas" só abre os 4 links com `?categoria=`. O catálogo completo só é linkado da home.
- `/download` existe e não está em nenhuma navegação.
- `projetos`, `maquinas` e `servicos` estão duplicadas entre `navbarDesktop.tsx` e `navbarMobile.tsx`, divergindo só em `size-5`/`size-6`. Um módulo compartilhado evitaria os menus divergirem.
- Bloco "Peças" está `hidden` nos dois arquivos (~100 linhas de JSX cada), aguardando integração externa.