### PR TITLE
Legibilidade e padronização das páginas institucionais

### DIFF
--- a/app/(site)/maquinas/[slug]/_components/aplicacoesProdutos.tsx
+++ b/app/(site)/maquinas/[slug]/_components/aplicacoesProdutos.tsx
@@ -13,15 +13,15 @@ export function AplicacoesProdutos({
     <section id='aplicacoes' className='scroll-mt-28 py-10 md:py-14'>
       <AnimatedContainer className='flex flex-col gap-8 md:flex-row md:items-start'>
         <div className='md:w-1/2'>
-          <h2 className='text-lg font-bold text-white md:text-xl'>
+          <h2 className='text-xl font-bold text-white md:text-2xl'>
             Aplicações e produtos
           </h2>
-          <p className='text-muted-foreground/70 mt-1 font-mono text-xs tracking-wider'>
+          <p className='text-muted-foreground/70 mt-1 font-mono text-sm tracking-wider'>
             {aplicacoes.categoriaPrincipal}
           </p>
 
           <details className='group mt-5 max-w-md border border-dashed border-[rgba(148,178,235,0.35)] bg-slate-900/60'>
-            <summary className='text-muted-foreground flex cursor-pointer list-none items-center justify-between px-4 py-3 font-mono text-sm select-none'>
+            <summary className='text-muted-foreground flex cursor-pointer list-none items-center justify-between px-4 py-3 font-mono text-base select-none'>
               Ver produtos compatíveis ({aplicacoes.produtos.length})
               <span className='text-accent transition-transform group-open:rotate-45'>
                 ＋
@@ -31,13 +31,13 @@ export function AplicacoesProdutos({
               {aplicacoes.produtos.map((p) => (
                 <li
                   key={p}
-                  className='text-muted-foreground rounded-full border border-[rgba(148,178,235,0.25)] px-3 py-1 text-xs'>
+                  className='text-muted-foreground rounded-full border border-[rgba(148,178,235,0.25)] px-3 py-1 text-sm'>
                   {p}
                 </li>
               ))}
             </ul>
           </details>
-          <p className='text-muted-foreground/50 mt-3 max-w-md text-xs italic'>
+          <p className='text-muted-foreground/50 mt-3 max-w-md text-sm italic'>
             Exemplos editoriais, sujeitos à validação técnica com produto,
             volume, embalagem e dosador.
           </p>
@@ -55,7 +55,7 @@ export function AplicacoesProdutos({
                   alt={`Categoria ${info.rotulo}`}
                   className='aspect-square w-full object-cover'
                 />
-                <figcaption className='absolute inset-x-0 bottom-0 bg-gradient-to-t from-[rgba(3,8,20,0.92)] to-transparent px-2.5 pt-5 pb-1.5 text-[11px] font-semibold tracking-wider text-white uppercase'>
+                <figcaption className='absolute inset-x-0 bottom-0 bg-gradient-to-t from-[rgba(3,8,20,0.92)] to-transparent px-2.5 pt-5 pb-1.5 text-[13px] font-semibold tracking-wider text-white uppercase'>
                   {info.rotulo}
                 </figcaption>
               </figure>

--- a/app/(site)/maquinas/[slug]/_components/conversao.tsx
+++ b/app/(site)/maquinas/[slug]/_components/conversao.tsx
@@ -10,10 +10,10 @@ export function Conversao({ maquina }: { maquina: MaquinaCatalogo }) {
   return (
     <section id='contato' className='scroll-mt-28 py-12 text-center md:py-16'>
       <AnimatedContainer>
-        <h2 className='text-xl font-bold text-white md:text-2xl'>
+        <h2 className='text-2xl font-bold text-balance text-white md:text-3xl'>
           Pronto para dimensionar a {maquina.nome} na sua operação?
         </h2>
-        <p className='text-muted-foreground mt-2'>
+        <p className='text-muted-foreground mt-2 text-lg text-pretty'>
           Fale com o time técnico-comercial da Profills.
         </p>
         <div className='mt-6 flex flex-wrap items-center justify-center gap-3'>

--- a/app/(site)/maquinas/[slug]/_components/embalagemBloco.tsx
+++ b/app/(site)/maquinas/[slug]/_components/embalagemBloco.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { AnimatedContainer } from '@/components/AnimatedContainer';
 import type { MaquinaCatalogo } from '@/lib/data/maquinas';
 import { cn } from '@/lib/utils';
+import { compostosJuntos } from '@/lib/utils/nbsp';
 
 const OptimizedEmbalagem3d = dynamic(
   () =>
@@ -22,7 +23,7 @@ export function EmbalagemBloco({ maquina }: { maquina: MaquinaCatalogo }) {
     <section id='embalagem' className='scroll-mt-28 py-10 md:py-14'>
       <AnimatedContainer className='flex flex-col items-center gap-8 md:flex-row'>
         <div className='md:w-1/2'>
-          <h2 className='text-lg font-bold text-white md:text-xl'>
+          <h2 className='text-xl font-bold text-white md:text-2xl'>
             A embalagem que ela entrega
           </h2>
           <dl className='mt-4 max-w-md font-mono'>
@@ -30,11 +31,11 @@ export function EmbalagemBloco({ maquina }: { maquina: MaquinaCatalogo }) {
               <div
                 key={item.rotulo}
                 className='flex items-baseline justify-between gap-4 border-b border-[rgba(148,178,235,0.15)] py-2 last:border-0'>
-                <dt className='text-muted-foreground/70 text-[11px] tracking-wider uppercase'>
+                <dt className='text-muted-foreground/70 text-[13px] tracking-wider uppercase'>
                   {item.rotulo}
                 </dt>
-                <dd className='max-w-[60%] text-right text-sm text-white'>
-                  {item.valor}
+                <dd className='max-w-[60%] text-right text-base text-pretty text-white'>
+                  {compostosJuntos(item.valor)}
                 </dd>
               </div>
             ))}
@@ -50,7 +51,7 @@ export function EmbalagemBloco({ maquina }: { maquina: MaquinaCatalogo }) {
                 alt={`Embalagem produzida pela ${maquina.nome}`}
                 className='h-64 w-full md:h-80'
               />
-              <p className='text-muted-foreground/50 mt-2 text-center font-mono text-[10px]'>
+              <p className='text-muted-foreground/50 mt-2 text-center font-mono text-xs'>
                 ⟲ arraste para girar o modelo 3D
               </p>
             </>

--- a/app/(site)/maquinas/[slug]/_components/escopoEngenharia.tsx
+++ b/app/(site)/maquinas/[slug]/_components/escopoEngenharia.tsx
@@ -1,5 +1,6 @@
 import { AnimatedContainer } from '@/components/AnimatedContainer';
 import type { MaquinaCatalogo } from '@/lib/data/maquinas';
+import { compostosJuntos } from '@/lib/utils/nbsp';
 
 interface EscopoEngenhariaProps {
   conteudo: NonNullable<MaquinaCatalogo['conteudoEngenharia']>;
@@ -10,11 +11,11 @@ export function EscopoEngenharia({ conteudo }: EscopoEngenhariaProps) {
     <section id='escopo' className='scroll-mt-28 py-10 md:py-14'>
       <AnimatedContainer className='flex flex-col gap-8 md:flex-row'>
         <div className='md:w-3/5'>
-          <h2 className='text-lg font-bold text-white md:text-xl'>
+          <h2 className='text-xl font-bold text-white md:text-2xl'>
             Escopo da solução
           </h2>
           {conteudo.escopo && (
-            <p className='text-muted-foreground mt-3 leading-relaxed'>
+            <p className='text-muted-foreground mt-3 text-lg leading-relaxed text-pretty'>
               {conteudo.escopo}
             </p>
           )}
@@ -24,7 +25,7 @@ export function EscopoEngenharia({ conteudo }: EscopoEngenhariaProps) {
             <span className='text-accent/60 absolute -top-2 -left-1 font-mono text-xs'>
               +
             </span>
-            <h3 className='font-mono text-xs font-semibold tracking-widest text-white uppercase'>
+            <h3 className='font-mono text-sm font-semibold tracking-widest text-white uppercase'>
               Composição da solução
             </h3>
             <dl className='mt-3 font-mono'>
@@ -32,11 +33,11 @@ export function EscopoEngenharia({ conteudo }: EscopoEngenhariaProps) {
                 <div
                   key={item.rotulo}
                   className='flex items-baseline justify-between gap-4 border-b border-[rgba(148,178,235,0.12)] py-2 last:border-0'>
-                  <dt className='text-muted-foreground/70 text-[11px] tracking-wider uppercase'>
+                  <dt className='text-muted-foreground/70 text-[13px] tracking-wider uppercase'>
                     {item.rotulo}
                   </dt>
-                  <dd className='max-w-[60%] text-right text-sm text-white'>
-                    {item.valor}
+                  <dd className='max-w-[60%] text-right text-base text-pretty text-white'>
+                    {compostosJuntos(item.valor)}
                   </dd>
                 </div>
               ))}

--- a/app/(site)/maquinas/[slug]/_components/fichaTecnica.tsx
+++ b/app/(site)/maquinas/[slug]/_components/fichaTecnica.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { AnimatedContainer } from '@/components/AnimatedContainer';
 import type { EspecificacaoItem, MaquinaCatalogo } from '@/lib/data/maquinas';
 import { cn } from '@/lib/utils';
+import { compostosJuntos } from '@/lib/utils/nbsp';
 
 function PlacaSpecs({
   titulo,
@@ -18,7 +19,7 @@ function PlacaSpecs({
       <span className='text-accent/60 absolute -top-2 -left-1 font-mono text-xs'>
         +
       </span>
-      <h3 className='flex items-center gap-2 font-mono text-xs font-semibold tracking-widest text-white uppercase'>
+      <h3 className='flex items-center gap-2 font-mono text-sm font-semibold tracking-widest text-white uppercase'>
         <span className='bg-accent inline-block h-1.5 w-1.5' />
         {titulo}
       </h3>
@@ -27,11 +28,11 @@ function PlacaSpecs({
           <div
             key={item.rotulo}
             className='flex items-baseline justify-between gap-4 border-b border-[rgba(148,178,235,0.12)] py-2 last:border-0'>
-            <dt className='text-muted-foreground/70 text-[11px] tracking-wider uppercase'>
+            <dt className='text-muted-foreground/70 text-[13px] tracking-wider uppercase'>
               {item.rotulo}
             </dt>
-            <dd className='max-w-[60%] text-right text-sm text-white'>
-              {item.valor}
+            <dd className='max-w-[60%] text-right text-base text-pretty text-white'>
+              {compostosJuntos(item.valor)}
             </dd>
           </div>
         ))}
@@ -47,10 +48,10 @@ export function FichaTecnica({ maquina }: { maquina: MaquinaCatalogo }) {
   return (
     <section id='ficha-tecnica' className='scroll-mt-28 py-10 md:py-14'>
       <AnimatedContainer>
-        <h2 className='text-lg font-bold text-white md:text-xl'>
+        <h2 className='text-xl font-bold text-white md:text-2xl'>
           Ficha técnica
         </h2>
-        <p className='text-muted-foreground/70 mt-1 font-mono text-xs tracking-wider'>
+        <p className='text-muted-foreground/70 mt-1 font-mono text-sm tracking-wider'>
           Fonte: Catálogo de Máquinas Profills 2026
         </p>
 
@@ -68,7 +69,7 @@ export function FichaTecnica({ maquina }: { maquina: MaquinaCatalogo }) {
           </PlacaSpecs>
         </div>
 
-        <p className='text-muted-foreground/50 mt-3 text-xs italic'>
+        <p className='text-muted-foreground/50 mt-3 text-sm italic'>
           Valores máximos de referência. A produção varia conforme produto,
           volume, embalagem e configuração do projeto. Especificações sujeitas a
           validação técnica de engenharia.

--- a/app/(site)/maquinas/[slug]/_components/heroDossie.tsx
+++ b/app/(site)/maquinas/[slug]/_components/heroDossie.tsx
@@ -4,6 +4,7 @@ import { AnimatedContainer } from '@/components/AnimatedContainer';
 import { NumberTicker } from '@/components/magicui/number-ticker';
 import type { MaquinaCatalogo } from '@/lib/data/maquinas';
 import { cn } from '@/lib/utils';
+import { compostosJuntos } from '@/lib/utils/nbsp';
 
 function Cantoneiras() {
   const base = 'absolute h-2.5 w-2.5 border-accent';
@@ -39,10 +40,10 @@ export function HeroDossie({ maquina, children }: HeroDossieProps) {
         <div className='flex items-center justify-between border-b border-dashed border-[rgba(148,178,235,0.25)] pb-3'>
           <span
             data-testid='categoria-hero'
-            className='text-accent font-mono text-[10px] tracking-[0.2em] uppercase'>
+            className='text-accent font-mono text-xs tracking-[0.2em] uppercase'>
             {maquina.categoria}
           </span>
-          <span className='text-muted-foreground/60 font-mono text-[10px] tracking-wider'>
+          <span className='text-muted-foreground/60 font-mono text-xs tracking-wider'>
             FICHA · CATÁLOGO 2026 · {maquina.paginaCatalogo}
           </span>
         </div>
@@ -53,20 +54,20 @@ export function HeroDossie({ maquina, children }: HeroDossieProps) {
               'w-full',
               maquina.imagens ? 'md:w-[45%]' : 'md:w-full'
             )}>
-            <h1 className='text-2xl leading-tight font-bold text-white md:text-4xl'>
+            <h1 className='text-2xl leading-tight font-bold text-pretty text-white md:text-4xl'>
               {maquina.nomeCompleto}
             </h1>
-            <p className='text-muted-foreground mt-3 max-w-md text-sm md:text-base'>
+            <p className='text-muted-foreground mt-3 max-w-md text-base text-pretty md:text-lg'>
               {maquina.headline}
             </p>
 
             <dl className='mt-5 w-full max-w-sm font-mono'>
               {temTicker && (
                 <div className='flex items-baseline justify-between gap-4 border-b border-[rgba(148,178,235,0.15)] py-2 last:border-0'>
-                  <dt className='text-muted-foreground/70 text-[11px] tracking-wider uppercase'>
+                  <dt className='text-muted-foreground/70 text-[13px] tracking-wider uppercase'>
                     Capacidade
                   </dt>
-                  <dd className='text-right text-sm font-semibold text-white'>
+                  <dd className='text-right text-base font-semibold text-white'>
                     <span data-ticker>
                       até{' '}
                       <NumberTicker
@@ -83,18 +84,18 @@ export function HeroDossie({ maquina, children }: HeroDossieProps) {
                 <div
                   key={item.rotulo}
                   className='flex items-baseline justify-between gap-4 border-b border-[rgba(148,178,235,0.15)] py-2 last:border-0'>
-                  <dt className='text-muted-foreground/70 text-[11px] tracking-wider uppercase'>
+                  <dt className='text-muted-foreground/70 text-[13px] tracking-wider uppercase'>
                     {item.rotulo}
                   </dt>
-                  <dd className='text-right text-sm font-semibold text-white'>
-                    {item.valor}
+                  <dd className='text-right text-base font-semibold text-pretty text-white'>
+                    {compostosJuntos(item.valor)}
                   </dd>
                 </div>
               ))}
             </dl>
 
             {temTicker && (
-              <p className='text-muted-foreground/50 mt-2 max-w-sm font-mono text-[10px] italic'>
+              <p className='text-muted-foreground/50 mt-2 max-w-sm font-mono text-xs italic'>
                 A produção varia conforme produto, volume, embalagem e
                 configuração do projeto.
               </p>

--- a/app/(site)/maquinas/[slug]/_components/relacionadas.tsx
+++ b/app/(site)/maquinas/[slug]/_components/relacionadas.tsx
@@ -33,7 +33,7 @@ export function Relacionadas({ maquina }: { maquina: MaquinaCatalogo }) {
       <AnimatedContainer>
         <Carousel opts={{ align: 'start' }}>
           <div className='mx-auto mb-4 flex w-full max-w-7xl items-center justify-between px-4 md:px-8'>
-            <h2 className='text-base font-bold text-white'>
+            <h2 className='text-lg font-bold text-white md:text-xl'>
               Máquinas relacionadas
             </h2>
             <div className='flex gap-2'>
@@ -56,11 +56,11 @@ export function Relacionadas({ maquina }: { maquina: MaquinaCatalogo }) {
                     alt={m.nomeCompleto}
                     className='mx-auto h-40 w-auto object-contain md:h-48'
                   />
-                  <p className='mt-3 text-sm font-semibold text-white'>
+                  <p className='mt-3 text-base font-semibold text-white'>
                     {m.nome}
                   </p>
                   {m.capacidadeMaxima && (
-                    <p className='text-muted-foreground/70 font-mono text-xs'>
+                    <p className='text-muted-foreground/70 font-mono text-sm'>
                       até {m.capacidadeMaxima.toLocaleString('pt-BR')} un/h
                     </p>
                   )}

--- a/app/(site)/maquinas/[slug]/_components/subNavMaquina.tsx
+++ b/app/(site)/maquinas/[slug]/_components/subNavMaquina.tsx
@@ -12,7 +12,7 @@ export function SubNavMaquina({ nome, secoes, children }: SubNavMaquinaProps) {
       aria-label='Seções da página'
       className='sticky top-0 z-40 -mx-4 border-b border-dashed border-[rgba(148,178,235,0.3)] bg-slate-900/95 backdrop-blur-sm md:top-16 md:-mx-8'>
       <div className='mx-auto flex max-w-7xl items-center gap-4 overflow-x-auto px-4 py-2 md:gap-6 md:px-8'>
-        <span className='shrink-0 font-mono text-sm font-bold text-white'>
+        <span className='shrink-0 font-mono text-base font-bold text-white'>
           {nome}
         </span>
         <span className='h-4 w-px shrink-0 bg-[rgba(148,178,235,0.25)]' />
@@ -20,7 +20,7 @@ export function SubNavMaquina({ nome, secoes, children }: SubNavMaquinaProps) {
           <a
             key={s.id}
             href={`#${s.id}`}
-            className='text-muted-foreground hover:text-foreground shrink-0 font-mono text-xs tracking-wider uppercase transition-colors'>
+            className='text-muted-foreground hover:text-foreground shrink-0 font-mono text-sm tracking-wider uppercase transition-colors'>
             {s.rotulo}
           </a>
         ))}

--- a/app/(site)/maquinas/[slug]/_components/videoMaquina.tsx
+++ b/app/(site)/maquinas/[slug]/_components/videoMaquina.tsx
@@ -11,7 +11,7 @@ export function VideoMaquina({ video, nome }: VideoMaquinaProps) {
   return (
     <section id='video' className='scroll-mt-28 py-10 md:py-14'>
       <AnimatedContainer>
-        <h2 className='text-lg font-bold text-white md:text-xl'>
+        <h2 className='text-xl font-bold text-white md:text-2xl'>
           Veja a {nome} em operação
         </h2>
         <div className='relative mt-4 border border-dashed border-[rgba(148,178,235,0.35)] p-2'>

--- a/app/(site)/maquinas/[slug]/_components/visaoGeral.tsx
+++ b/app/(site)/maquinas/[slug]/_components/visaoGeral.tsx
@@ -6,10 +6,10 @@ export function VisaoGeral({ maquina }: { maquina: MaquinaCatalogo }) {
     <section id='visao-geral' className='scroll-mt-28 py-10 md:py-14'>
       <AnimatedContainer className='flex flex-col gap-8 md:flex-row'>
         <div className='md:w-3/5'>
-          <h2 className='text-lg font-bold text-white md:text-xl'>
+          <h2 className='text-xl font-bold text-white md:text-2xl'>
             Visão geral
           </h2>
-          <p className='text-muted-foreground mt-3 leading-relaxed'>
+          <p className='text-muted-foreground mt-3 text-lg leading-relaxed text-pretty'>
             {maquina.descritivo}
           </p>
         </div>
@@ -19,14 +19,14 @@ export function VisaoGeral({ maquina }: { maquina: MaquinaCatalogo }) {
               <span className='text-accent/60 absolute -top-2 -left-1 font-mono text-xs'>
                 +
               </span>
-              <h3 className='font-mono text-xs font-semibold tracking-widest text-white uppercase'>
+              <h3 className='font-mono text-sm font-semibold tracking-widest text-white uppercase'>
                 Recursos e especiais
               </h3>
               <ul className='mt-3 space-y-2'>
                 {maquina.recursos.map((r) => (
                   <li
                     key={r}
-                    className='text-muted-foreground flex gap-2 text-sm'>
+                    className='text-muted-foreground flex gap-2 text-base'>
                     <span className='text-accent'>▸</span>
                     {r}
                   </li>

--- a/app/(site)/maquinas/[slug]/page.tsx
+++ b/app/(site)/maquinas/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function MaquinaPage({ params }: MaquinaPageProps) {
           <SpecificationModal
             maquinaSlug={maquina.slug}
             maquinaNome={maquina.nome}
-            triggerClassName='h-7 px-3 text-xs'
+            triggerClassName='h-9 px-4 text-xs'
           />
         </SubNavMaquina>
 

--- a/lib/utils/nbsp.test.ts
+++ b/lib/utils/nbsp.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { compostosJuntos } from './nbsp';
+
+const NBSP = '\u00a0';
+
+describe('compostosJuntos', () => {
+  it('troca espaços ao redor de " + " por NBSP', () => {
+    expect(compostosJuntos('PET + PE; PET + PE + alumínio')).toBe(
+      `PET${NBSP}+${NBSP}PE; PET${NBSP}+${NBSP}PE${NBSP}+${NBSP}alumínio`
+    );
+  });
+
+  it('não altera valores sem " + "', () => {
+    expect(compostosJuntos('220 V / 60 Hz')).toBe('220 V / 60 Hz');
+    expect(compostosJuntos('temporizada · bomba · volumétrica')).toBe(
+      'temporizada · bomba · volumétrica'
+    );
+  });
+
+  it('não toca "+" colado (sem espaços)', () => {
+    expect(compostosJuntos('A+B')).toBe('A+B');
+  });
+});

--- a/lib/utils/nbsp.ts
+++ b/lib/utils/nbsp.ts
@@ -1,0 +1,11 @@
+const NBSP = '\u00a0';
+
+/**
+ * Mantém compostos técnicos juntos na quebra de linha: "PET + PE + alumínio"
+ * não pode quebrar em "PET + PE + / alumínio". Troca o espaço ao redor de " + "
+ * por NBSP, tornando cada composto atômico — a quebra cai nos separadores
+ * de lista ("; "), onde ela é natural.
+ */
+export function compostosJuntos(valor: string): string {
+  return valor.replaceAll(' + ', `${NBSP}+${NBSP}`);
+}


### PR DESCRIPTION
## O que muda

Aumento de fontes em todo o template `/maquinas/[slug]` (as 15 máquinas), pensado para leitores mais velhos:

| Elemento | Antes → Depois |
|---|---|
| Rótulos mono das specs | 11px → 13px |
| Valores das specs | 14px → 16px |
| Notas de rodapé | 10–12px → 12–14px |
| H2 de seção | 18/20px → 20/24px |
| Parágrafos descritivos | 16px → 18px |
| Headline do hero | 14/16px → 16/18px |
| CTA final | 20/24px → 24/30px |
| Subnav, chips, cards relacionados | +1 degrau cada |

## Quebras de texto

Com o corpo maior, apareceram quebras feias — tratadas junto:

- `text-pretty` em valores de specs, parágrafos e h1: elimina órfãs (`280 / mm`, `alguns / sólidos`, `Pouch / Mecânica`)
- `text-balance` no h2 do CTA (3 linhas equilibradas no mobile)
- `lib/utils/nbsp.ts` (`compostosJuntos` + teste): NBSP em torno de ` + ` nos valores renderizados — compostos como "PET + PE + alumínio" não partem mais no meio; a quebra cai nos `;`

## Ajuste de proporção

Botão do subnav sticky: `h-7` → `h-9` (o `default` do Button), acompanhando a nova escala da barra.

## Verificação

- 213/213 testes (3 novos do helper)
- Screenshots desktop (1440px) e mobile (390px) seção a seção, antes/depois
- `bun run lint` está quebrado no repo (eslint-plugin-react × ESLint 10) — pré-existente, não relacionado

## Fix de acessibilidade incluído: página invisível com reduced motion

Com "reduzir animações" ativo no sistema, o site inteiro renderizava invisível: o `AnimatedContainer` trocava `motion.div` (SSR, `opacity:0` inline) por `div` estática no cliente, e o React não corrige atributos em hydration mismatch. A árvore agora é sempre a mesma e o reduced motion zera só a `transition`. Teste de regressão trava a invariante; verificado com `prefers-reduced-motion` emulado (páginas renderizam completas, zero warnings de hidratação no log).
---

## Também neste PR: três páginas institucionais no mesmo padrão

### `/montar-fabrica` — dossiê de projeto
- Hero prancheta (cantoneiras, 3 etapas como specs mono), form em placa técnica com submit dentro do `<form>`, copy enxuto (1 destaque por bloco, antes ~10)
- Imagem: PNG 3500px/1.3MB → webp 1600px/**340KB** com `priority` + `sizes` + `placeholder='blur'`
- `page.tsx` server com `metadata` (antes 100% client, sem SEO)

### `/servicos-personalizados` — fix de rotas + navy
- **Bug corrigido:** os 4 itens de "Outros Serviços" na navbar apontavam todos para a rota seca; agora cada um leva à sua âncora (`#corte-laser`, `#dobra-cnc`, `#usinagem-cnc`, `#soldagem`) e a página ganhou a seção "Serviços industriais" com os 6 serviços do antigo carrossel mudo
- Hero com h1 (não tinha), vídeo `object-cover` (era `object-fill` esticado), cards sem distorção, `metadata` nova
- ContactForm multi-etapas mantido; botões nos tokens navy e indicador de progresso visível no fundo escuro

### `/montar-maquina` — configurador na prancheta
- Seletores como placas mono 01/02 (fora gradientes azul/roxo — roxo não existe na paleta), seleção com borda accent, ícones sobre chip claro
- Recomendação como mini-dossiê — testada com combinações reais (Pouch+Líquidos → Linha Pouch Speed; Fardo+Líquidos → Linha TC4U)
- Form migrado de useState manual para react-hook-form + zod (`montarMaquinaFormSchema`, o mesmo da API); `page.tsx` server com `metadata`

### Verificação (as três)
- 213/213 testes; typecheck limpo (resta 1 erro pré-existente em `webglSupport.test.ts`, fora do diff)
- Screenshots desktop 1440px e mobile 390px; layout do contato de serviços confirmado por medição DOM
- Envio real dos forms depende de `.env` (comportamento documentado)

