### PR TITLE
Falha de envio de e-mail deixa de ser silenciosa

### DIFF
--- a/app/api/__tests__/rotas-email.test.ts
+++ b/app/api/__tests__/rotas-email.test.ts
@@ -1,0 +1,129 @@
+import type { NextRequest } from 'next/server';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* Falha de envio de e-mail NÃO pode virar "sucesso" para o visitante:
+   antes, 4 rotas engoliam o erro do sendMail num try/catch interno e
+   respondiam 200/success:true com a solicitação perdida. O contrato agora:
+   envio ok → 200; envio falhou → 500 com success:false (o client mostra
+   o toast de erro e o visitante tenta de novo). */
+
+vi.mock('@/lib/emails/monte-fabrica/email-monte-fabrica', () => ({
+  sendMonteFabricaEmail: vi.fn()
+}));
+vi.mock('@/lib/emails/montar-maquina/email-montar-maquina', () => ({
+  sendMontarMaquinaEmail: vi.fn()
+}));
+vi.mock('@/lib/emails/solicitar-especificacoes/email-especificacoes', () => ({
+  sendSpecificationEmail: vi.fn()
+}));
+vi.mock('@/lib/emails/contact-form/email-contact', () => ({
+  sendContactEmail: vi.fn()
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() }
+}));
+
+import { sendContactEmail } from '@/lib/emails/contact-form/email-contact';
+import { sendMontarMaquinaEmail } from '@/lib/emails/montar-maquina/email-montar-maquina';
+import { sendMonteFabricaEmail } from '@/lib/emails/monte-fabrica/email-monte-fabrica';
+import { sendSpecificationEmail } from '@/lib/emails/solicitar-especificacoes/email-especificacoes';
+
+import { POST as postContact } from '../contact/route';
+import { POST as postMontarMaquina } from '../montar-maquina/route';
+import { POST as postMonteFabrica } from '../monte-fabrica/route';
+import { POST as postSpecifications } from '../specifications/route';
+
+function req(payload: unknown): NextRequest {
+  return new Request('http://localhost/api/teste', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }) as unknown as NextRequest;
+}
+
+const casos = [
+  {
+    nome: 'monte-fabrica',
+    post: postMonteFabrica,
+    sendMock: sendMonteFabricaEmail,
+    payload: {
+      nome: 'Teste Unitário',
+      email: 'teste@example.com',
+      telefone: '(41) 99999-9999',
+      empresa: 'Empresa Teste',
+      mensagem: 'Mensagem de teste com tamanho suficiente.'
+    }
+  },
+  {
+    nome: 'montar-maquina',
+    post: postMontarMaquina,
+    sendMock: sendMontarMaquinaEmail,
+    payload: {
+      nome: 'Teste Unitário',
+      email: 'teste@example.com',
+      empresa: 'Empresa Teste',
+      contato: '(41) 99999-9999',
+      detalhes: 'Detalhes de teste com tamanho suficiente.',
+      selectedPackaging: 'Sachê',
+      selectedProductType: 'Líquido'
+    }
+  },
+  {
+    nome: 'specifications',
+    post: postSpecifications,
+    sendMock: sendSpecificationEmail,
+    payload: {
+      nome: 'Teste Unitário',
+      email: 'teste@example.com',
+      telefone: '(41) 99999-9999',
+      empresa: 'Empresa Teste',
+      maquinaSlug: 'envasadora-stand-up-pouch-speed',
+      maquinaNome: 'Linha Pouch Speed',
+      observacoes: 'Observações de teste.'
+    }
+  },
+  {
+    nome: 'contact',
+    post: postContact,
+    sendMock: sendContactEmail,
+    payload: {
+      email: 'teste@example.com',
+      phone: '(41) 99999-9999',
+      cep: '80010-000',
+      street: 'Rua Teste',
+      number: '123',
+      complement: '',
+      neighborhood: 'Centro',
+      city: 'Curitiba',
+      state: 'PR',
+      material: 'Papelão',
+      service: 'Embalagem personalizada',
+      finish: 'Fosco',
+      details: 'Detalhes de teste.'
+    }
+  }
+];
+
+describe.each(casos)('POST /api/$nome', ({ post, sendMock, payload }) => {
+  beforeEach(() => {
+    vi.mocked(sendMock).mockReset();
+  });
+
+  it('responde 200 quando o e-mail é enviado', async () => {
+    vi.mocked(sendMock).mockResolvedValue(undefined as never);
+    const res = await post(req(payload));
+    const corpo = await res.json();
+    expect(res.status).toBe(200);
+    expect(corpo.success).toBe(true);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('responde 500 quando o envio de e-mail falha', async () => {
+    vi.mocked(sendMock).mockRejectedValue(new Error('SMTP indisponível'));
+    const res = await post(req(payload));
+    const corpo = await res.json();
+    expect(res.status).toBe(500);
+    expect(corpo.success).toBe(false);
+  });
+});

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -9,12 +9,10 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const validatedData = contactFormSchema.parse(body);
 
-    // Enviar e-mail com os dados do contato
-    try {
-      await sendContactEmail(validatedData);
-    } catch (emailError) {
-      console.error('❌ Erro no envio do e-mail:', emailError);
-    }
+    /* Sem try/catch aqui: falha de envio precisa virar 500 para o visitante
+       ver o erro — engolir e responder sucesso perdia a solicitação em
+       silêncio. O catch externo loga e responde. */
+    await sendContactEmail(validatedData);
 
     return NextResponse.json(
       {

--- a/app/api/montar-maquina/route.ts
+++ b/app/api/montar-maquina/route.ts
@@ -10,11 +10,10 @@ export async function POST(request: NextRequest) {
 
     const validatedData = montarMaquinaFormSchema.parse(body);
 
-    try {
-      await sendMontarMaquinaEmail(validatedData);
-    } catch (emailError) {
-      logger.error('❌ Erro no envio do e-mail:', emailError);
-    }
+    /* Sem try/catch aqui: falha de envio precisa virar 500 para o visitante
+       ver o erro — engolir e responder sucesso perdia a solicitação em
+       silêncio. O catch externo loga e responde. */
+    await sendMontarMaquinaEmail(validatedData);
 
     return NextResponse.json(
       {

--- a/app/api/monte-fabrica/route.ts
+++ b/app/api/monte-fabrica/route.ts
@@ -9,12 +9,10 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const validatedData = monteFabricaFormSchema.parse(body);
 
-    // Enviar e-mail com os dados do projeto
-    try {
-      await sendMonteFabricaEmail(validatedData);
-    } catch (emailError) {
-      logger.error('❌ Erro no envio do e-mail:', emailError);
-    }
+    /* Sem try/catch aqui: falha de envio precisa virar 500 para o visitante
+       ver o erro — engolir e responder sucesso perdia a solicitação em
+       silêncio. O catch externo loga e responde. */
+    await sendMonteFabricaEmail(validatedData);
 
     return NextResponse.json(
       {

--- a/app/api/specifications/route.ts
+++ b/app/api/specifications/route.ts
@@ -9,12 +9,10 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const validatedData = specificationFormSchema.parse(body);
 
-    // Enviar e-mail com as especificações
-    try {
-      await sendSpecificationEmail(validatedData);
-    } catch (emailError) {
-      logger.error('❌ Erro no envio do e-mail:', emailError);
-    }
+    /* Sem try/catch aqui: falha de envio precisa virar 500 para o visitante
+       ver o erro — engolir e responder sucesso perdia a solicitação em
+       silêncio. O catch externo loga e responde. */
+    await sendSpecificationEmail(validatedData);
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## O problema

Quatro das cinco rotas de formulário (`contact`, `monte-fabrica`, `montar-maquina`, `specifications`) embrulhavam o `sendMail` num `try/catch` interno que apenas logava o erro — a rota respondia `200/success:true` mesmo com o e-mail perdido. O visitante via o toast "Solicitação enviada com sucesso!" e a solicitação sumia sem rastro. A `download-catalog` era a única que deixava a falha virar 500.

Encontrado durante o teste de ponta a ponta dos 5 fluxos de e-mail (verificação adversarial dos handlers + log do server).

## O fix

O erro do envio agora propaga ao `catch` externo, que loga e responde `500/success:false` — os clients já tratam `!response.ok` com toast de erro, então o visitante fica sabendo e pode tentar de novo. Nenhuma mudança de contrato no caminho feliz.

## Verificação

- 8 testes novos em `app/api/__tests__/rotas-email.test.ts`: as 4 rotas nos dois caminhos (envio ok → 200 · envio falha → 500), com os módulos de e-mail mockados
- Suíte completa: 221/221
- Caminho feliz real segue funcionando: os 5 fluxos foram disparados contra o dev server com `.env` válido nesta rodada — todos 200 com envio confirmado no log

Base em `main` — independente do PR #26.