### PR TITLE
fix(seo): serve os 35 cards de /maquinas no HTML

### DIFF
--- a/app/(site)/(home)/_components/heroCarrossel/__tests__/heroCarrossel.test.tsx
+++ b/app/(site)/(home)/_components/heroCarrossel/__tests__/heroCarrossel.test.tsx
@@ -45,7 +45,7 @@ vi.mock('next/image', () => ({
     className?: string;
     style?: React.CSSProperties;
   }) => (
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    // eslint-disable-next-line @next/next/no-img-element
     <img alt={alt} className={className} style={style} />
   )
 }));

--- a/app/(site)/(home)/_components/heroCarrossel/__tests__/heroSlideStage.test.tsx
+++ b/app/(site)/(home)/_components/heroCarrossel/__tests__/heroSlideStage.test.tsx
@@ -34,7 +34,7 @@ vi.mock('next/image', () => ({
     className?: string;
     style?: React.CSSProperties;
   }) => (
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    // eslint-disable-next-line @next/next/no-img-element
     <img alt={alt} className={className} style={style} />
   )
 }));

--- a/app/(site)/clientes/_components/clientesGrid.tsx
+++ b/app/(site)/clientes/_components/clientesGrid.tsx
@@ -20,14 +20,17 @@ export default function ClientesGrid() {
     if (!q) return listaClientes;
     return listaClientes.filter(
       (cliente) =>
-        cliente.slug.includes(q) ||
-        normalizeQuery(cliente.name).includes(q)
+        cliente.slug.includes(q) || normalizeQuery(cliente.name).includes(q)
     );
   }, [query]);
 
-  useEffect(() => {
+  // Query nova reinicia a paginação. Ajuste de estado durante o render em
+  // vez de effect: evita um render extra com a contagem antiga.
+  const [queryAnterior, setQueryAnterior] = useState(query);
+  if (query !== queryAnterior) {
+    setQueryAnterior(query);
     setVisibleCount(CHUNK_SIZE);
-  }, [query]);
+  }
 
   useEffect(() => {
     const el = sentinelRef.current;
@@ -61,8 +64,7 @@ export default function ClientesGrid() {
           <BlurFade key={`empty-${query}`} delay={0.05} direction='up' inView>
             <div className='border-border/40 mx-auto mt-10 max-w-md rounded-md border border-dashed bg-background/60 p-6 text-center'>
               <p className='text-sm text-muted-foreground'>
-                Nenhum cliente encontrado para
-                {' '}
+                Nenhum cliente encontrado para{' '}
                 <span className='text-foreground font-medium'>“{query}”</span>.
               </p>
             </div>

--- a/app/(site)/maquinas/__tests__/page.test.tsx
+++ b/app/(site)/maquinas/__tests__/page.test.tsx
@@ -1,0 +1,32 @@
+import { maquinasCatalogo } from '@/lib/data/maquinas';
+
+import MaquinasPage from '../page';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+// Reproduz o comportamento do Next no prerender estático: useSearchParams
+// lança um bailout para CSR, e a subárvore dentro do Suspense mais próximo
+// é substituída pelo fallback no HTML. Se algum componente da grade voltar a
+// chamar o hook, este teste fica vermelho de novo (issue #30).
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => '/maquinas',
+  useSearchParams: () => {
+    throw new Error('BAILOUT_TO_CLIENT_SIDE_RENDERING');
+  }
+}));
+
+describe('/maquinas (HTML servido)', () => {
+  const html = renderToStaticMarkup(<MaquinasPage />);
+
+  it('serve os 35 cards do catálogo no HTML, sem depender de hidratação', () => {
+    expect(maquinasCatalogo.length).toBe(35);
+    for (const maquina of maquinasCatalogo) {
+      expect(html).toContain(`>${maquina.nome}<`);
+    }
+  });
+
+  it('não serve o fallback "Carregando..." no lugar da grade', () => {
+    expect(html).not.toContain('Carregando');
+  });
+});

--- a/app/(site)/maquinas/_components/cardMaquinas/maquinaCard.tsx
+++ b/app/(site)/maquinas/_components/cardMaquinas/maquinaCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import Image from 'next/image';
 
@@ -27,12 +27,6 @@ export default function MaquinaCard({
 
   const [imgLoaded, setImgLoaded] = useState(false);
   const [pkgLoaded, setPkgLoaded] = useState(false);
-
-  // Reset dos estados quando a máquina muda (importante para filtros)
-  useEffect(() => {
-    setImgLoaded(false);
-    setPkgLoaded(false);
-  }, [maquina.slug]);
 
   // Delay escalonado para animação suave (máximo 0.3s para melhor performance)
   const animationDelay = Math.min(index * 0.03, 0.3);

--- a/app/(site)/maquinas/_components/catalogoMaquinas.tsx
+++ b/app/(site)/maquinas/_components/catalogoMaquinas.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 import { GridPattern } from '@/components/layout/gridPatternBg';
 import { Button } from '@/components/ui/button';
@@ -19,8 +19,7 @@ function normalizar(texto: string) {
   return texto.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
 }
 
-function MaquinasContent() {
-  const searchParams = useSearchParams();
+export default function CatalogoMaquinas() {
   const router = useRouter();
   const pathname = usePathname();
   const [categoriaFiltro, setCategoriaFiltro] = useState<string>('Todas');
@@ -49,8 +48,12 @@ function MaquinasContent() {
     router.replace(newUrl, { scroll: false });
   };
 
-  // Lê os parâmetros da URL e aplica os filtros
+  // Lê os filtros da URL uma vez, depois da hidratação. Não usa
+  // useSearchParams de propósito: o hook aborta o prerender estático e o HTML
+  // de /maquinas saía sem os cards (issue #30). A URL só muda por
+  // router.replace daqui mesmo, então uma leitura no mount basta.
   useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
     const categoriaFromUrl = searchParams.get('categoria');
     const embalagemFromUrl = searchParams.get('embalagem');
     const buscaFromUrl = searchParams.get('q');
@@ -76,7 +79,7 @@ function MaquinasContent() {
     if (buscaFromUrl) {
       setBusca(buscaFromUrl);
     }
-  }, [searchParams]);
+  }, []);
 
   // Digitação atualiza a listagem na hora; a URL só depois de uma pausa,
   // para o replace do router não rodar a cada tecla
@@ -246,18 +249,5 @@ function MaquinasContent() {
         )}
       </div>
     </div>
-  );
-}
-
-export default function CatalogoMaquinas() {
-  return (
-    <Suspense
-      fallback={
-        <div className='tema-navy bg-background flex min-h-screen w-full items-center justify-center'>
-          <div className='text-muted-foreground'>Carregando...</div>
-        </div>
-      }>
-      <MaquinasContent />
-    </Suspense>
   );
 }

--- a/app/(site)/maquinas/_components/catalogoMaquinas.tsx
+++ b/app/(site)/maquinas/_components/catalogoMaquinas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { usePathname, useRouter } from 'next/navigation';
 
@@ -52,6 +52,7 @@ export default function CatalogoMaquinas() {
   // useSearchParams de propósito: o hook aborta o prerender estático e o HTML
   // de /maquinas saía sem os cards (issue #30). A URL só muda por
   // router.replace daqui mesmo, então uma leitura no mount basta.
+  /* eslint-disable react-hooks/set-state-in-effect -- sincroniza com a URL, sistema externo */
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
     const categoriaFromUrl = searchParams.get('categoria');
@@ -80,10 +81,18 @@ export default function CatalogoMaquinas() {
       setBusca(buscaFromUrl);
     }
   }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Digitação atualiza a listagem na hora; a URL só depois de uma pausa,
-  // para o replace do router não rodar a cada tecla
+  // para o replace do router não rodar a cada tecla. Pula o mount: ali o
+  // closure ainda tem o estado inicial ('Todas') e o replace apagava o
+  // filtro que veio da URL.
+  const montou = useRef(false);
   useEffect(() => {
+    if (!montou.current) {
+      montou.current = true;
+      return;
+    }
     const timer = setTimeout(() => {
       updateUrl(categoriaFiltro, embalagemFiltro, busca);
     }, 300);

--- a/app/(site)/montar-maquina/_components/configuradorMaquina.tsx
+++ b/app/(site)/montar-maquina/_components/configuradorMaquina.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import Image from 'next/image';
 import Link from 'next/link';
@@ -32,7 +32,6 @@ import { cn } from '@/lib/utils';
 
 import {
   type ContactFormData,
-  type MachineRecommendation,
   getBestMachineRecommendation,
   initialContactFormData
 } from './combinacaoMaquinas';
@@ -64,25 +63,19 @@ const productTypes = [
 export default function ConfiguradorMaquina() {
   const [selectedPackaging, setSelectedPackaging] = useState<string>('');
   const [selectedProductType, setSelectedProductType] = useState<string>('');
-  const [recommendation, setRecommendation] =
-    useState<MachineRecommendation | null>(null);
   const [contactForm, setContactForm] = useState<ContactFormData>(
     initialContactFormData
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Verificar compatibilidade quando seleções mudarem
-  useEffect(() => {
-    if (selectedPackaging && selectedProductType) {
-      const bestRecommendation = getBestMachineRecommendation(
-        selectedPackaging,
-        selectedProductType
-      );
-      setRecommendation(bestRecommendation);
-    } else {
-      setRecommendation(null);
-    }
-  }, [selectedPackaging, selectedProductType]);
+  // Recomendação é derivada das seleções: memo em vez de estado + effect
+  const recommendation = useMemo(
+    () =>
+      selectedPackaging && selectedProductType
+        ? getBestMachineRecommendation(selectedPackaging, selectedProductType)
+        : null,
+    [selectedPackaging, selectedProductType]
+  );
 
   const handleContactFormChange = (
     field: keyof ContactFormData,

--- a/app/(standalone)/sorteio-fispal-2026/page.tsx
+++ b/app/(standalone)/sorteio-fispal-2026/page.tsx
@@ -188,7 +188,8 @@ export default function SorteioFispal2026() {
           <BlurFade delay={0.4} inView>
             <p className='mt-5 max-w-xl text-base leading-relaxed text-white/85 md:text-lg'>
               Concorra a uma{' '}
-              <strong className='font-semibold text-white'>TV 65"</strong>, uma{' '}
+              <strong className='font-semibold text-white'>TV 65&quot;</strong>,
+              uma{' '}
               <strong className='font-semibold text-white'>
                 Churrasqueira Champions Grill
               </strong>{' '}

--- a/app/__tests__/layout.test.tsx
+++ b/app/__tests__/layout.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// next/font precisa do compilador do Next; no jsdom vira stub
+vi.mock('next/font/google', () => ({
+  Geist: () => ({ variable: 'font-geist-sans' }),
+  Geist_Mono: () => ({ variable: 'font-geist-mono' })
+}));
+
+vi.mock('next/script', () => ({
+  default: ({ id }: { id: string }) => <script id={id} />
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/'
+}));
+
+// Toaster (sonner) lê matchMedia, ausente no jsdom
+vi.stubGlobal('matchMedia', () => ({
+  matches: false,
+  media: '',
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn()
+}));
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_META_PIXEL_ID = '123';
+  process.env.NEXT_PUBLIC_GA_ID = 'G-TEST';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('RootLayout', () => {
+  // O servidor sempre emite o <noscript> dentro do <body> (React move filhos
+  // de <html> para lá), mas a árvore React no cliente diz html > noscript e
+  // o React avisa "cannot be a child of <html>" e sinaliza hydration error.
+  // O aviso de aninhamento também sai num render de cliente puro.
+  it('não gera aviso de aninhamento inválido para os scripts de tracking', async () => {
+    const erros: string[] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      erros.push(args.map(String).join(' '));
+    });
+
+    const { default: RootLayout } = await import('../layout');
+    render(
+      <RootLayout>
+        <main>conteúdo</main>
+      </RootLayout>
+    );
+
+    // O único aviso aceitável é o do próprio container do RTL (<div> não
+    // pode conter <html>); qualquer outro é um elemento do layout no lugar
+    // errado.
+    const aninhamento = erros
+      .filter((e) => e.includes('cannot be a child'))
+      .filter((e) => !e.includes('<html> div'));
+    expect(aninhamento).toEqual([]);
+  });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -81,9 +81,9 @@ export default function RootLayout({
         {children}
         <JsonLd data={organizacaoSchema()} />
         <JsonLd data={websiteSchema()} />
+        {gaId && <GoogleAnalytics gaId={gaId} />}
+        {metaPixelId && <MetaPixel pixelId={metaPixelId} />}
       </body>
-      {gaId && <GoogleAnalytics gaId={gaId} />}
-      {metaPixelId && <MetaPixel pixelId={metaPixelId} />}
     </html>
   );
 }

--- a/components/carouselHome.tsx
+++ b/components/carouselHome.tsx
@@ -96,6 +96,8 @@ function Carousel({
 
   React.useEffect(() => {
     if (!api) return;
+    // Sincroniza com a API do embla (sistema externo), não deriva de props
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     onSelect(api);
     api.on('reInit', onSelect);
     api.on('select', onSelect);

--- a/components/layout/metaPixel.tsx
+++ b/components/layout/metaPixel.tsx
@@ -38,6 +38,7 @@ s.parentNode.insertBefore(t,s)}(window, document,'script',
 fbq('init', '${pixelId}');`}
       </Script>
       <noscript>
+        {/* eslint-disable-next-line @next/next/no-img-element -- pixel de 1px, não é conteúdo */}
         <img
           height='1'
           width='1'

--- a/components/magicui/animated-grid-pattern.tsx
+++ b/components/magicui/animated-grid-pattern.tsx
@@ -13,8 +13,7 @@ import { cn } from '@/lib/utils';
 
 import { motion } from 'motion/react';
 
-export interface AnimatedGridPatternProps
-  extends ComponentPropsWithoutRef<'svg'> {
+export interface AnimatedGridPatternProps extends ComponentPropsWithoutRef<'svg'> {
   width?: number;
   height?: number;
   x?: number;
@@ -79,6 +78,8 @@ export function AnimatedGridPattern({
   // Update squares to animate in
   useEffect(() => {
     if (dimensions.width && dimensions.height) {
+      // Depende das dimensões medidas pelo ResizeObserver (sistema externo)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSquares(generateSquares(numSquares));
     }
   }, [dimensions, numSquares, generateSquares]);

--- a/components/magicui/pixel-image.tsx
+++ b/components/magicui/pixel-image.tsx
@@ -57,6 +57,8 @@ export const PixelImage = ({
   }, [customGrid, grid]);
 
   useEffect(() => {
+    // Dispara a animação de entrada só depois do mount (evita flash no SSR)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsVisible(true);
     const t = setTimeout(() => setShowColor(true), colorRevealDelay);
     return () => clearTimeout(t);
@@ -73,6 +75,8 @@ export const PixelImage = ({
         ${(col + 1) * (100 / cols)}% ${(row + 1) * (100 / rows)}%,
         ${col * (100 / cols)}% ${(row + 1) * (100 / rows)}%
       )`;
+      // Delay aleatório por peça é intencional; memo fixa o sorteio por grid
+      // eslint-disable-next-line react-hooks/purity
       const delay = Math.random() * maxAnimationDelay;
       return { clipPath, delay };
     });

--- a/components/magicui/text-animate.tsx
+++ b/components/magicui/text-animate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ElementType, memo } from 'react';
+import { ElementType, memo, useMemo } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -318,7 +318,7 @@ const TextAnimateBase = ({
   accessible = true,
   ...props
 }: TextAnimateProps) => {
-  const MotionComponent = motion.create(Component);
+  const MotionComponent = useMemo(() => motion.create(Component), [Component]);
 
   let segments: string[] = [];
   switch (by) {
@@ -384,6 +384,7 @@ const TextAnimateBase = ({
 
   return (
     <AnimatePresence mode='popLayout'>
+      {/* eslint-disable-next-line react-hooks/static-components -- `as` é prop, o motion.create fica memoizado por Component */}
       <MotionComponent
         variants={finalVariants.container as Variants}
         initial='hidden'

--- a/components/modelo3d/hooks/useOptimized3DModel.ts
+++ b/components/modelo3d/hooks/useOptimized3DModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ModelViewerElement } from '@google/model-viewer';
+
 import { isWebGLAvailable } from './webglSupport';
 
 // Cache global para modelos 3D já carregados
@@ -30,6 +31,8 @@ export function useOptimized3DModel({
 
   // Detecta suporte a WebGL uma vez no client.
   useEffect(() => {
+    // Só dá para sondar o WebGL no client, depois do mount
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setWebglSupported(isWebGLAvailable());
   }, []);
 
@@ -62,10 +65,14 @@ export function useOptimized3DModel({
       : false;
 
     if (eager && isLayoutVisible) {
+      // Lê getClientRects() do DOM (sistema externo) para ignorar a árvore
+      // invisível do hero mobile/desktop
+      /* eslint-disable react-hooks/set-state-in-effect */
       setIsVisible(true);
       if (!hasBeenLoaded) {
         setShouldRender(true);
       }
+      /* eslint-enable react-hooks/set-state-in-effect */
     }
 
     const observer = new IntersectionObserver(

--- a/components/modelo3d/hooks/webglSupport.test.ts
+++ b/components/modelo3d/hooks/webglSupport.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-
 import { isWebGLAvailable, resetWebGLCache } from './webglSupport';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 afterEach(() => {
   resetWebGLCache();
@@ -11,7 +10,7 @@ afterEach(() => {
 describe('isWebGLAvailable', () => {
   it('retorna true quando o canvas fornece um contexto webgl', () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
-      {} as unknown as WebGL2RenderingContext
+      {} as never
     );
     expect(isWebGLAvailable()).toBe(true);
   });

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -96,6 +96,8 @@ function Carousel({
 
   React.useEffect(() => {
     if (!api) return;
+    // Sincroniza com a API do embla (sistema externo), não deriva de props
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     onSelect(api);
     api.on('reInit', onSelect);
     api.on('select', onSelect);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,22 @@ import nextTs from 'eslint-config-next/typescript';
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      // Prefixo _ marca argumento/variável descartada de propósito
+      // (padrão dos mocks de motion nos testes do hero)
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          ignoreRestSiblings: true
+        }
+      ]
+    }
+  },
   globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts'])
 ]);
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^25.9.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "eslint": "^10.4.0",
+    "eslint": "^9.39.0",
     "eslint-config-next": "16.2.6",
     "jsdom": "^29.1.1",
     "prettier": "3.8.3",


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.99.0
Closes #30

## O problema

`/maquinas` chegava no navegador só com o fallback "Carregando...". Os 35 cards apareciam depois da hidratação. O `CatalogoMaquinas` chamava `useSearchParams`, e isso faz o Next abortar o prerender estático da subárvore dentro do `Suspense`.

## O que muda

- A página continua estática e o servidor manda a grade completa no HTML.
- Os filtros da URL (`categoria`, `embalagem`, `q`) são lidos no cliente uma vez, depois da hidratação, com `window.location.search`. O `router.replace` que atualiza a URL continua igual.
- Sai o `Suspense` e o "Carregando...".

Escolhi não filtrar no servidor, como a issue sugeria, porque ler `searchParams` no `page.tsx` tornaria a rota dinâmica por request. O canonical já aponta para `/maquinas` sem filtro, e é essa versão que o Google indexa.

Efeito colateral: quem abre um link já filtrado vê os 35 cards por um instante antes do filtro entrar. Antes via o "Carregando...".

## De carona

`GoogleAnalytics` e `MetaPixel` estavam fora do `<body>`, como filhos diretos de `<html>`. O `<noscript>` do pixel gerava aviso de aninhamento inválido e hydration error no console em toda página. Movidos para dentro do `<body>`.

## Testes

- `app/(site)/maquinas/__tests__/page.test.tsx`: mocka `useSearchParams` lançando o bailout do Next e afirma que os 35 nomes estão no HTML e "Carregando" não está. Vermelho no código anterior.
- `app/__tests__/layout.test.tsx`: renderiza o layout e afirma que não há aviso "cannot be a child". Vermelho no código anterior.

Suíte: 238/238. Build de produção com `next start -p 3010`:

```
curl -s localhost:3010/maquinas | wc -c                 # 181269 (antes 63699)
curl -s localhost:3010/maquinas | grep -c Carregando    # 0 (antes 1)
```
## Lint e tipos (segundo commit)

`bun run lint` crashava na `main`: o `eslint-plugin-react` 7.37 ainda usa `context.getFilename`, removido no ESLint 10. Fixei o ESLint em ^9 (`eslint-config-next` aceita >=9). Com o lint rodando, apareceram 13 erros e 21 avisos, todos anteriores a esta branch. Zerei:

- Estado derivado vira `useMemo` ou ajuste durante o render (`configuradorMaquina`, `clientesGrid`, `text-animate`).
- `maquinaCard` perde um effect de reset redundante: o pai já remonta o card por `key`.
- Effect que sincroniza com sistema externo (URL, embla, ResizeObserver, WebGL) ganha `eslint-disable` com o motivo na linha.
- `no-unused-vars` passa a ignorar prefixo `_`, o padrão dos mocks nos testes do hero.
- `webglSupport.test.ts`: cast do mock compila no `tsc`.

De carona, um bug real no catálogo: o debounce da busca disparava no mount com o closure inicial e fazia `router.replace('/maquinas')`, apagando o filtro que veio da URL. Agora pula o mount. Verificado em browser limpo: `?categoria=Stand-up pouch` mostra 4 cards e a URL mantém o parâmetro.

Estado final: `bun run lint` 0 erros e 0 avisos, `tsc --noEmit` limpo, 238/238 testes.