### PR TITLE
feat: eventos de indicação no GA4 e Meta Pixel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,5 +98,5 @@ Antes de redesenhar qualquer coisa, procurar spec/plan existente sobre o tema �
 - `text-animate` existe em `ui/` e `magicui/` — verificar qual variante a rota vizinha já usa antes de importar.
 - Tema é light-mode único com seções dark (`bg-secondary`) — não há toggle dark/light.
 - Conteúdo do site é em pt-BR.
-- Eventos de analytics só saem de `lib/analytics/`; nomes e parâmetros são contrato com o admin do GA4 (dimensões `codigo_vendedor`, `formulario`).
+- Eventos de Indicação só saem de `lib/analytics/`; nomes e parâmetros são contrato com o admin do GA4 (dimensões `codigo_vendedor`, `formulario`). O PageView do Pixel e o `page_view` do GA continuam em `components/layout/metaPixel.tsx` e no `GoogleAnalytics` do root layout.
 - Contato comercial (telefone, WhatsApp, e-mail de vendas) nunca é hardcoded: vem de `useContatoComercial()` no client ou de `CONTATO_PADRAO` no servidor, porque a Indicação (`?ref=`) troca esses valores por visitante. Suporte, Compras e JSON-LD usam sempre `CONTATO_PADRAO`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ lib/crm/                  ← cliente server-only da API do CRM (referral code)
 lib/indicacao/            ← cookie assinado, tipos e destinatário do lead
 components/indicacao/     ← IndicacaoProvider, useContatoComercial, BotaoEspecialista
 lib/data/contatos.ts      ← fonte única dos contatos padrão (vendas, suporte, compras)
+lib/analytics/            ← eventos de GA4 e Meta (só código do vendedor, nunca dado pessoal)
 ```
 
 ## Onde colocar cada coisa
@@ -97,4 +98,5 @@ Antes de redesenhar qualquer coisa, procurar spec/plan existente sobre o tema �
 - `text-animate` existe em `ui/` e `magicui/` — verificar qual variante a rota vizinha já usa antes de importar.
 - Tema é light-mode único com seções dark (`bg-secondary`) — não há toggle dark/light.
 - Conteúdo do site é em pt-BR.
+- Eventos de analytics só saem de `lib/analytics/`; nomes e parâmetros são contrato com o admin do GA4 (dimensões `codigo_vendedor`, `formulario`).
 - Contato comercial (telefone, WhatsApp, e-mail de vendas) nunca é hardcoded: vem de `useContatoComercial()` no client ou de `CONTATO_PADRAO` no servidor, porque a Indicação (`?ref=`) troca esses valores por visitante. Suporte, Compras e JSON-LD usam sempre `CONTATO_PADRAO`.

--- a/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
+++ b/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
@@ -2,14 +2,22 @@ import { act } from 'react';
 
 import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 import type { CatalogRequestData } from '@/lib/schemas/catalog-request';
+import { sendGAEvent } from '@next/third-parties/google';
 import { renderHook } from '@testing-library/react';
 
 import { useCatalogForm } from './useCatalogForm';
+import { toast } from 'sonner';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/lib/analytics/indicacao', () => ({
-  registrarLeadIndicacao: vi.fn()
-}));
+/* Espião em cima da função REAL: as asserções de argumento continuam valendo e
+   o caso "analytics falha" exercita o engolir-erro de verdade, sem depender de
+   try/catch nos 5 call sites. */
+vi.mock('@/lib/analytics/indicacao', async (importOriginal) => {
+  const real =
+    await importOriginal<typeof import('@/lib/analytics/indicacao')>();
+  return { registrarLeadIndicacao: vi.fn(real.registrarLeadIndicacao) };
+});
+vi.mock('@next/third-parties/google', () => ({ sendGAEvent: vi.fn() }));
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn() }
 }));
@@ -30,6 +38,8 @@ function respostaOk(corpo: unknown) {
 
 beforeEach(() => {
   vi.mocked(registrarLeadIndicacao).mockClear();
+  vi.mocked(sendGAEvent).mockReset();
+  vi.mocked(toast.error).mockClear();
 });
 
 afterEach(() => {
@@ -85,6 +95,29 @@ describe('useCatalogForm', () => {
     });
 
     expect(registrarLeadIndicacao).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
     expect(result.current.status).toBe('idle');
+  });
+
+  it('analytics quebrado não derruba o envio', async () => {
+    vi.mocked(sendGAEvent).mockImplementation(() => {
+      throw new Error('dataLayer corrompido');
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          respostaOk({ success: true, indicacao: { codigo: 'MARIA-10' } })
+        )
+    );
+
+    const { result } = renderHook(() => useCatalogForm());
+    await act(async () => {
+      await result.current.onSubmit(valores);
+    });
+
+    expect(result.current.status).toBe('success');
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
+++ b/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
@@ -1,0 +1,90 @@
+import { act } from 'react';
+
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
+import type { CatalogRequestData } from '@/lib/schemas/catalog-request';
+import { renderHook } from '@testing-library/react';
+
+import { useCatalogForm } from './useCatalogForm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/analytics/indicacao', () => ({
+  registrarLeadIndicacao: vi.fn()
+}));
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}));
+
+const valores: CatalogRequestData = {
+  name: 'Teste Unitário',
+  document: '52998224725',
+  phone: '(41) 99999-9999',
+  email: 'teste@example.com'
+};
+
+function respostaOk(corpo: unknown) {
+  return {
+    ok: true,
+    json: async () => corpo
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.mocked(registrarLeadIndicacao).mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useCatalogForm', () => {
+  it('registra o lead com o código devolvido pela rota', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          respostaOk({ success: true, indicacao: { codigo: 'MARIA-10' } })
+        )
+    );
+
+    const { result } = renderHook(() => useCatalogForm());
+    await act(async () => {
+      await result.current.onSubmit(valores);
+    });
+
+    expect(registrarLeadIndicacao).toHaveBeenCalledWith('catalogo', 'MARIA-10');
+    expect(result.current.status).toBe('success');
+  });
+
+  it('sem indicação registra o lead com código nulo', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(respostaOk({ success: true, indicacao: null }))
+    );
+
+    const { result } = renderHook(() => useCatalogForm());
+    await act(async () => {
+      await result.current.onSubmit(valores);
+    });
+
+    expect(registrarLeadIndicacao).toHaveBeenCalledWith('catalogo', null);
+  });
+
+  it('não registra lead quando a rota falha', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ message: 'Erro' })
+      } as Response)
+    );
+
+    const { result } = renderHook(() => useCatalogForm());
+    await act(async () => {
+      await result.current.onSubmit(valores);
+    });
+
+    expect(registrarLeadIndicacao).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
+  });
+});

--- a/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.ts
+++ b/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.ts
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 import {
   type CatalogRequestData,
   catalogRequestSchema
@@ -43,6 +44,9 @@ export function useCatalogForm() {
           payload?.message || 'Não foi possível enviar. Tente novamente.'
         );
       }
+
+      const corpo = await res.json().catch(() => ({}));
+      registrarLeadIndicacao('catalogo', corpo?.indicacao?.codigo ?? null);
 
       setSubmittedEmail(values.email);
       setStatus('success');

--- a/app/(site)/maquinas/[slug]/_components/__tests__/specificationModal.test.tsx
+++ b/app/(site)/maquinas/[slug]/_components/__tests__/specificationModal.test.tsx
@@ -1,10 +1,42 @@
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import SpecificationModal from '../specificationModal';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/analytics/indicacao', () => ({
+  registrarLeadIndicacao: vi.fn()
+}));
+
+/** Preenche e envia o formulário do modal. */
+async function enviarFormulario() {
+  const user = userEvent.setup();
+  render(
+    <SpecificationModal
+      maquinaSlug='linha-producao-completa-envase'
+      maquinaNome='Linha de Produção Ponta a Ponta'
+    />
+  );
+
+  await user.click(
+    screen.getByRole('button', {
+      name: /Solicitar proposta técnica e comercial/i
+    })
+  );
+
+  await user.type(screen.getByLabelText(/Nome Completo/i), 'Fulano Teste');
+  await user.type(screen.getByLabelText(/E-mail/i), 'fulano@example.com');
+  await user.type(screen.getByLabelText(/Telefone/i), '11999998888');
+
+  await user.click(screen.getByRole('button', { name: /Enviar solicitação/i }));
+}
 
 describe('SpecificationModal', () => {
+  beforeEach(() => {
+    vi.mocked(registrarLeadIndicacao).mockClear();
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -48,5 +80,43 @@ describe('SpecificationModal', () => {
       maquinaSlug: 'linha-producao-completa-envase',
       maquinaNome: 'Linha de Produção Ponta a Ponta'
     });
+  });
+
+  it('registra o lead com o código devolvido pela rota', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          indicacao: { codigo: 'MARIA-10' }
+        })
+      })
+    );
+
+    await enviarFormulario();
+
+    await waitFor(() => {
+      expect(registrarLeadIndicacao).toHaveBeenCalledWith(
+        'especificacoes',
+        'MARIA-10'
+      );
+    });
+  });
+
+  it('não registra lead quando a rota responde 500', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ success: false })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await enviarFormulario();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(registrarLeadIndicacao).not.toHaveBeenCalled();
   });
 });

--- a/app/(site)/maquinas/[slug]/_components/specificationModal.tsx
+++ b/app/(site)/maquinas/[slug]/_components/specificationModal.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 import {
   type SpecificationFormData,
   specificationFormSchema
@@ -71,6 +72,12 @@ export default function SpecificationModal({
       if (!response.ok) {
         throw new Error('Erro ao enviar solicitação');
       }
+
+      const result = await response.json().catch(() => ({}));
+      registrarLeadIndicacao(
+        'especificacoes',
+        result?.indicacao?.codigo ?? null
+      );
 
       toast.success(
         <p className='font-bold'>Solicitação enviada com sucesso!</p>,

--- a/app/(site)/montar-fabrica/_components/formularioMontarFabrica.tsx
+++ b/app/(site)/montar-fabrica/_components/formularioMontarFabrica.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 import imgFabricaCompleta from '@/lib/images/extras/FabricaRemderNewB.png';
 import {
   type MonteFabricaFormData,
@@ -57,6 +58,11 @@ export default function FormularioMontarFabrica() {
       }
 
       console.log('✅ Solicitação enviada com sucesso:', result);
+
+      registrarLeadIndicacao(
+        'monte-fabrica',
+        result?.indicacao?.codigo ?? null
+      );
 
       toast.success('Solicitação enviada com sucesso!', {
         description:

--- a/app/(site)/montar-maquina/_components/configuradorMaquina.tsx
+++ b/app/(site)/montar-maquina/_components/configuradorMaquina.tsx
@@ -12,6 +12,7 @@ import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 // Importar imagens das embalagens
 import embalagemEspeciais from '@/lib/images/embalagensPequenas/especiais.png';
 import embalagemFardo from '@/lib/images/embalagensPequenas/fardo.png';
@@ -112,6 +113,11 @@ export default function ConfiguradorMaquina() {
       if (!response.ok) {
         throw new Error(result?.message || 'Erro ao enviar solicitação');
       }
+
+      registrarLeadIndicacao(
+        'montar-maquina',
+        result?.indicacao?.codigo ?? null
+      );
 
       toast.success('Solicitação enviada com sucesso!', {
         description:

--- a/app/(site)/servicos-personalizados/_components/contact-form/hooks/useContactForm.ts
+++ b/app/(site)/servicos-personalizados/_components/contact-form/hooks/useContactForm.ts
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { registrarLeadIndicacao } from '@/lib/analytics/indicacao';
 import {
   type ContactFormData,
   contactFormSchema,
@@ -166,6 +167,8 @@ export function useContactForm() {
       }
 
       console.log('✅ Solicitação enviada com sucesso:', result);
+
+      registrarLeadIndicacao('contato', result?.indicacao?.codigo ?? null);
 
       // Feedback visual de sucesso
       toast.success('Solicitação enviada com sucesso!', {

--- a/app/api/__tests__/rotas-email.test.ts
+++ b/app/api/__tests__/rotas-email.test.ts
@@ -131,6 +131,7 @@ describe.each(casos)('POST /api/$nome', ({ post, sendMock, payload }) => {
     const corpo = await res.json();
     expect(res.status).toBe(200);
     expect(corpo.success).toBe(true);
+    expect(corpo.indicacao).toEqual({ codigo: 'MARIA-10' });
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'teste@example.com' }),
@@ -146,7 +147,9 @@ describe.each(casos)('POST /api/$nome', ({ post, sendMock, payload }) => {
     vi.mocked(sendMock).mockResolvedValue(undefined as never);
 
     const res = await post(req(payload));
+    const corpo = await res.json();
     expect(res.status).toBe(200);
+    expect(corpo.indicacao).toBeNull();
     expect(sendMock).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'teste@example.com' }),
       expect.objectContaining({ para: 'caixa@profills.test', vendedor: null })
@@ -198,6 +201,7 @@ describe('POST /api/download-catalog', () => {
       })
     );
     expect(res.status).toBe(200);
+    expect((await res.json()).indicacao).toBeNull();
     expect(sendLeadNotification).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'teste@example.com' }),
       expect.objectContaining({ para: 'caixa@profills.test', vendedor: null })
@@ -214,6 +218,7 @@ describe('POST /api/download-catalog', () => {
       })
     );
     expect(res.status).toBe(200);
+    expect((await res.json()).indicacao).toEqual({ codigo: 'MARIA-10' });
     expect(sendLeadNotification).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'teste@example.com' }),
       expect.objectContaining({ para: 'maria@profills.com.br' })

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -23,7 +23,11 @@ export async function POST(request: NextRequest) {
         data: {
           id: Date.now(),
           timestamp: new Date().toISOString()
-        }
+        },
+        /* Só o código: o client usa para o evento de analytics. */
+        indicacao: destinatario.vendedor
+          ? { codigo: destinatario.vendedor.referral_code }
+          : null
       },
       { status: 200 }
     );

--- a/app/api/download-catalog/route.ts
+++ b/app/api/download-catalog/route.ts
@@ -32,7 +32,16 @@ export async function POST(request: NextRequest) {
       sendLeadNotification(data, destinatario)
     ]);
 
-    return NextResponse.json({ success: true }, { status: 200 });
+    return NextResponse.json(
+      {
+        success: true,
+        /* Só o código: o client usa para o evento de analytics. */
+        indicacao: destinatario.vendedor
+          ? { codigo: destinatario.vendedor.referral_code }
+          : null
+      },
+      { status: 200 }
+    );
   } catch (error) {
     logger.error('Erro ao processar solicitação de catálogo:', error);
 

--- a/app/api/montar-maquina/route.ts
+++ b/app/api/montar-maquina/route.ts
@@ -21,7 +21,11 @@ export async function POST(request: NextRequest) {
       {
         success: true,
         message: 'Solicitação enviada com sucesso!',
-        data: { id: Date.now(), timestamp: new Date().toISOString() }
+        data: { id: Date.now(), timestamp: new Date().toISOString() },
+        /* Só o código: o client usa para o evento de analytics. */
+        indicacao: destinatario.vendedor
+          ? { codigo: destinatario.vendedor.referral_code }
+          : null
       },
       { status: 200 }
     );

--- a/app/api/monte-fabrica/route.ts
+++ b/app/api/monte-fabrica/route.ts
@@ -23,7 +23,11 @@ export async function POST(request: NextRequest) {
         data: {
           id: Date.now(),
           timestamp: new Date().toISOString()
-        }
+        },
+        /* Só o código: o client usa para o evento de analytics. */
+        indicacao: destinatario.vendedor
+          ? { codigo: destinatario.vendedor.referral_code }
+          : null
       },
       { status: 200 }
     );

--- a/app/api/specifications/route.ts
+++ b/app/api/specifications/route.ts
@@ -23,7 +23,11 @@ export async function POST(request: NextRequest) {
         data: {
           id: Date.now(),
           timestamp: new Date().toISOString()
-        }
+        },
+        /* Só o código: o client usa para o evento de analytics. */
+        indicacao: destinatario.vendedor
+          ? { codigo: destinatario.vendedor.referral_code }
+          : null
       },
       { status: 200 }
     );

--- a/components/indicacao/indicacaoProvider.test.tsx
+++ b/components/indicacao/indicacaoProvider.test.tsx
@@ -1,10 +1,19 @@
 import { act } from 'react';
 
+import { registrarChegadaIndicacao } from '@/lib/analytics/indicacao';
+
 import { IndicacaoProvider } from './indicacaoProvider';
 import { useContatoComercial } from './useContatoComercial';
 import { hydrateRoot } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* Só o disparo é mockado: `marcarChegadaNaSessao` roda de verdade para o
+   teste exercitar o sessionStorage do jsdom. */
+vi.mock('@/lib/analytics/indicacao', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/analytics/indicacao')>()),
+  registrarChegadaIndicacao: vi.fn()
+}));
 
 function jwtFalso(payload: unknown) {
   const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64url');
@@ -27,14 +36,47 @@ const arvore = (
   </IndicacaoProvider>
 );
 
+function cookieDoVendedor(codigo: string) {
+  document.cookie = `profills_indicacao=${jwtFalso({
+    codigo,
+    nome: 'Maria Silva',
+    email: 'maria@profills.com.br',
+    contato: '11987654321',
+    consultadoEm: '2026-09-02T12:00:00.000Z'
+  })}; path=/`;
+}
+
+async function hidratar() {
+  const container = document.createElement('div');
+  container.innerHTML = renderToString(arvore);
+  document.body.appendChild(container);
+
+  let root: ReturnType<typeof hydrateRoot> | undefined;
+  await act(async () => {
+    root = hydrateRoot(container, arvore);
+  });
+
+  return {
+    container,
+    async desmontar() {
+      await act(async () => {
+        root?.unmount();
+      });
+      container.remove();
+    }
+  };
+}
+
 beforeEach(() => {
   (
     globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
   ).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.mocked(registrarChegadaIndicacao).mockClear();
 });
 
 afterEach(() => {
   document.cookie = 'profills_indicacao=; max-age=0; path=/';
+  window.sessionStorage.clear();
 });
 
 describe('IndicacaoProvider', () => {
@@ -73,5 +115,24 @@ describe('IndicacaoProvider', () => {
       root?.unmount();
     });
     container.remove();
+  });
+
+  it('registra a chegada uma vez por sessão, com o código do vendedor', async () => {
+    cookieDoVendedor('MARIA-10');
+
+    const primeira = await hidratar();
+    expect(registrarChegadaIndicacao).toHaveBeenCalledTimes(1);
+    expect(registrarChegadaIndicacao).toHaveBeenCalledWith('MARIA-10');
+    await primeira.desmontar();
+
+    const segunda = await hidratar();
+    expect(registrarChegadaIndicacao).toHaveBeenCalledTimes(1);
+    await segunda.desmontar();
+  });
+
+  it('sem cookie não registra chegada', async () => {
+    const montagem = await hidratar();
+    expect(registrarChegadaIndicacao).not.toHaveBeenCalled();
+    await montagem.desmontar();
   });
 });

--- a/components/indicacao/indicacaoProvider.tsx
+++ b/components/indicacao/indicacaoProvider.tsx
@@ -1,8 +1,17 @@
 'use client';
 
-import { createContext, useContext, useSyncExternalStore } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useSyncExternalStore
+} from 'react';
 import type { ReactNode } from 'react';
 
+import {
+  marcarChegadaNaSessao,
+  registrarChegadaIndicacao
+} from '@/lib/analytics/indicacao';
 import {
   extrairTokenIndicacao,
   lerCookieIndicacaoDoBrowser
@@ -48,6 +57,16 @@ function estadoServidor() {
 
 export function IndicacaoProvider({ children }: { children: ReactNode }) {
   const estado = useSyncExternalStore(assinar, lerEstado, estadoServidor);
+
+  /* Chegada pelo link do vendedor: só no cliente, uma vez por sessão do
+     navegador. `estado` só troca de referência quando o token do cookie
+     muda, então o efeito não repete a cada render. */
+  useEffect(() => {
+    if (estado.status !== 'indicado') return;
+    const codigo = estado.vendedor.codigo;
+    if (marcarChegadaNaSessao(codigo)) registrarChegadaIndicacao(codigo);
+  }, [estado]);
+
   return (
     <IndicacaoContext.Provider value={estado}>
       {children}

--- a/components/indicacao/indicacaoProvider.tsx
+++ b/components/indicacao/indicacaoProvider.tsx
@@ -58,9 +58,16 @@ function estadoServidor() {
 export function IndicacaoProvider({ children }: { children: ReactNode }) {
   const estado = useSyncExternalStore(assinar, lerEstado, estadoServidor);
 
-  /* Chegada pelo link do vendedor: só no cliente, uma vez por sessão do
-     navegador. `estado` só troca de referência quando o token do cookie
-     muda, então o efeito não repete a cada render. */
+  /* Chegada pelo link do vendedor: só no cliente, uma vez por aba
+     (`sessionStorage` é por aba). Visitante com cookie que abre aba nova, ou
+     que volta dias depois, conta de novo — decisão do produto. `estado` só
+     troca de referência quando o token do cookie muda, então o efeito não
+     repete a cada render.
+
+     O evento só chega ao GA porque este efeito roda depois de o
+     `GoogleAnalytics` criar o `dataLayer`: o `useSyncExternalStore` força um
+     segundo commit e o efeito cai nele. `sendGAEvent` sem `dataLayer`
+     descarta o evento com um warn, não enfileira. */
   useEffect(() => {
     if (estado.status !== 'indicado') return;
     const codigo = estado.vendedor.codigo;

--- a/components/layout/metaPixel.tsx
+++ b/components/layout/metaPixel.tsx
@@ -5,11 +5,7 @@ import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import Script from 'next/script';
 
-declare global {
-  interface Window {
-    fbq?: (...args: unknown[]) => void;
-  }
-}
+/* O tipo de `window.fbq` vive em types/fbq.d.ts — lib/analytics também usa. */
 
 type MetaPixelProps = { pixelId: string };
 

--- a/docs/superpowers/specs/2026-09-02-indicacao-vendedor-design.md
+++ b/docs/superpowers/specs/2026-09-02-indicacao-vendedor-design.md
@@ -175,10 +175,14 @@ Decisões fechadas com o dono do produto:
 1. Registrar duas coisas por vendedor: chegada pelo link e lead atribuído.
 2. Só o código do vendedor vai para GA e Meta. Nunca nome, e-mail, telefone do vendedor nem dado do lead.
 3. Meta: só eventos customizados (`fbq('trackCustom', ...)`); o evento padrão `Lead` não é disparado.
-4. A chegada conta uma vez por sessão do navegador, marcada em `sessionStorage` na chave `indicacao_registrada:<CODIGO>`.
+4. A chegada conta uma vez por aba (`sessionStorage` é por aba), marcada na chave `indicacao_registrada:<CODIGO>`. Visitante com cookie que abre aba nova, ou que volta dias depois, conta de novo — é assim por decisão do produto.
 5. O lead conta só quando o handler de fato mandou o e-mail ao vendedor; o handler devolve `indicacao: { codigo } | null` no JSON de sucesso.
 6. Lead sem indicação também dispara, com `codigo_vendedor: 'nenhum'`.
 
 O disparo vive em `lib/analytics/indicacao.ts`: GA ou Pixel ausentes viram no-op, analytics nunca quebra a página. A chegada sai do `IndicacaoProvider` (efeito de cliente, depois da hidratação); o lead sai de cada hook de formulário, no caminho de sucesso.
+
+O `IndicacaoProvider` só existe no grupo `(site)`: páginas do grupo `(standalone)` (landings) não disparam chegada, mesmo com o cookie posto. O lead, esse sim, sai de qualquer formulário que use os hooks instrumentados.
+
+Antes de emitir, o código passa pelo formato do CRM (`lib/indicacao/codigo.ts`, `^[A-Z0-9-]{3,20}$`): código fora do formato não vira chegada, e no lead vira `codigo_vendedor: 'nenhum'` — a dimensão do GA4 não recebe lixo de querystring.
 
 `codigo_vendedor` e `formulario` precisam ser registrados como dimensões personalizadas de escopo de evento no admin do GA4; depois disso os relatórios levam de 24 a 48 h para mostrar os valores.

--- a/docs/superpowers/specs/2026-09-02-indicacao-vendedor-design.md
+++ b/docs/superpowers/specs/2026-09-02-indicacao-vendedor-design.md
@@ -158,3 +158,27 @@ export const CONTATO_PADRAO = {
 ## 7. Fora de escopo
 
 Card do consultor, banner de cookies, rate limit no CRM, `cacheComponents`, números reais de Suporte e Compras (TODO existente), link do botão do FAQ.
+
+## 8. Analytics (2026-09-02)
+
+Duas coisas são medidas por vendedor: a chegada pelo link `?ref=` e o lead atribuído a ele.
+
+| Onde | Chegada                                   | Lead                                               |
+| ---- | ----------------------------------------- | -------------------------------------------------- |
+| GA4  | `indicacao_chegada` `{ codigo_vendedor }` | `indicacao_lead` `{ codigo_vendedor, formulario }` |
+| Meta | `IndicacaoChegada` `{ codigo_vendedor }`  | `IndicacaoLead` `{ codigo_vendedor, formulario }`  |
+
+`formulario` é um de `contato`, `catalogo`, `montar-maquina`, `monte-fabrica`, `especificacoes`.
+
+Decisões fechadas com o dono do produto:
+
+1. Registrar duas coisas por vendedor: chegada pelo link e lead atribuído.
+2. Só o código do vendedor vai para GA e Meta. Nunca nome, e-mail, telefone do vendedor nem dado do lead.
+3. Meta: só eventos customizados (`fbq('trackCustom', ...)`); o evento padrão `Lead` não é disparado.
+4. A chegada conta uma vez por sessão do navegador, marcada em `sessionStorage` na chave `indicacao_registrada:<CODIGO>`.
+5. O lead conta só quando o handler de fato mandou o e-mail ao vendedor; o handler devolve `indicacao: { codigo } | null` no JSON de sucesso.
+6. Lead sem indicação também dispara, com `codigo_vendedor: 'nenhum'`.
+
+O disparo vive em `lib/analytics/indicacao.ts`: GA ou Pixel ausentes viram no-op, analytics nunca quebra a página. A chegada sai do `IndicacaoProvider` (efeito de cliente, depois da hidratação); o lead sai de cada hook de formulário, no caminho de sucesso.
+
+`codigo_vendedor` e `formulario` precisam ser registrados como dimensões personalizadas de escopo de evento no admin do GA4; depois disso os relatórios levam de 24 a 48 h para mostrar os valores.

--- a/lib/analytics/indicacao.test.ts
+++ b/lib/analytics/indicacao.test.ts
@@ -37,6 +37,36 @@ describe('registrarChegadaIndicacao', () => {
   });
 });
 
+describe('validação do código antes de emitir', () => {
+  it('aceita código só de dígitos, no formato do CRM', () => {
+    registrarChegadaIndicacao('41999998888');
+
+    expect(ga).toHaveBeenCalledWith('event', 'indicacao_chegada', {
+      codigo_vendedor: '41999998888'
+    });
+  });
+
+  it('não dispara chegada quando o código está fora do formato', () => {
+    registrarChegadaIndicacao('MARIA.SILVA@X');
+
+    expect(ga).not.toHaveBeenCalled();
+    expect(window.fbq).not.toHaveBeenCalled();
+  });
+
+  it('lead com código fora do formato vira "nenhum"', () => {
+    registrarLeadIndicacao('contato', 'MARIA.SILVA@X');
+
+    expect(ga).toHaveBeenCalledWith('event', 'indicacao_lead', {
+      codigo_vendedor: 'nenhum',
+      formulario: 'contato'
+    });
+    expect(window.fbq).toHaveBeenCalledWith('trackCustom', 'IndicacaoLead', {
+      codigo_vendedor: 'nenhum',
+      formulario: 'contato'
+    });
+  });
+});
+
 describe('registrarLeadIndicacao', () => {
   it('manda o evento de lead com código e formulário', () => {
     registrarLeadIndicacao('catalogo', 'MARIA-10');

--- a/lib/analytics/indicacao.test.ts
+++ b/lib/analytics/indicacao.test.ts
@@ -1,0 +1,105 @@
+import { sendGAEvent } from '@next/third-parties/google';
+
+import {
+  marcarChegadaNaSessao,
+  registrarChegadaIndicacao,
+  registrarLeadIndicacao
+} from './indicacao';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@next/third-parties/google', () => ({
+  sendGAEvent: vi.fn()
+}));
+
+const ga = vi.mocked(sendGAEvent);
+
+beforeEach(() => {
+  ga.mockReset();
+  window.fbq = vi.fn();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  delete window.fbq;
+  window.sessionStorage.clear();
+});
+
+describe('registrarChegadaIndicacao', () => {
+  it('manda o evento de chegada para GA e Meta só com o código', () => {
+    registrarChegadaIndicacao('MARIA-10');
+
+    expect(ga).toHaveBeenCalledWith('event', 'indicacao_chegada', {
+      codigo_vendedor: 'MARIA-10'
+    });
+    expect(window.fbq).toHaveBeenCalledWith('trackCustom', 'IndicacaoChegada', {
+      codigo_vendedor: 'MARIA-10'
+    });
+  });
+});
+
+describe('registrarLeadIndicacao', () => {
+  it('manda o evento de lead com código e formulário', () => {
+    registrarLeadIndicacao('catalogo', 'MARIA-10');
+
+    expect(ga).toHaveBeenCalledWith('event', 'indicacao_lead', {
+      codigo_vendedor: 'MARIA-10',
+      formulario: 'catalogo'
+    });
+    expect(window.fbq).toHaveBeenCalledWith('trackCustom', 'IndicacaoLead', {
+      codigo_vendedor: 'MARIA-10',
+      formulario: 'catalogo'
+    });
+  });
+
+  it('sem indicação manda codigo_vendedor "nenhum"', () => {
+    registrarLeadIndicacao('contato', null);
+
+    expect(ga).toHaveBeenCalledWith('event', 'indicacao_lead', {
+      codigo_vendedor: 'nenhum',
+      formulario: 'contato'
+    });
+    expect(window.fbq).toHaveBeenCalledWith('trackCustom', 'IndicacaoLead', {
+      codigo_vendedor: 'nenhum',
+      formulario: 'contato'
+    });
+  });
+
+  it('não lança quando o Pixel não carregou', () => {
+    delete window.fbq;
+    expect(() => registrarLeadIndicacao('contato', null)).not.toThrow();
+    expect(ga).toHaveBeenCalledTimes(1);
+  });
+
+  it('não lança quando o GA falha, e ainda manda para o Meta', () => {
+    ga.mockImplementation(() => {
+      throw new Error('GA não carregado');
+    });
+
+    expect(() => registrarLeadIndicacao('contato', 'MARIA-10')).not.toThrow();
+    expect(window.fbq).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('marcarChegadaNaSessao', () => {
+  it('devolve true na primeira chamada e false na segunda', () => {
+    expect(marcarChegadaNaSessao('MARIA-10')).toBe(true);
+    expect(marcarChegadaNaSessao('MARIA-10')).toBe(false);
+  });
+
+  it('marca por código: outro código volta a ser primeira vez', () => {
+    expect(marcarChegadaNaSessao('MARIA-10')).toBe(true);
+    expect(marcarChegadaNaSessao('JOAO-7')).toBe(true);
+  });
+
+  it('devolve false quando o sessionStorage está bloqueado', () => {
+    const setItem = vi
+      .spyOn(window.sessionStorage.__proto__, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('storage bloqueado');
+      });
+
+    expect(marcarChegadaNaSessao('MARIA-10')).toBe(false);
+
+    setItem.mockRestore();
+  });
+});

--- a/lib/analytics/indicacao.ts
+++ b/lib/analytics/indicacao.ts
@@ -1,3 +1,4 @@
+import { normalizarCodigo } from '@/lib/indicacao/codigo';
 import { sendGAEvent } from '@next/third-parties/google';
 
 export type FormularioLead =
@@ -14,7 +15,7 @@ function enviar(nomeGa: string, nomeMeta: string, params: Params) {
   try {
     sendGAEvent('event', nomeGa, params);
   } catch {
-    /* GA não carregado */
+    /* GA ausente só gera warn; o catch cobre `dataLayer` corrompido por extensão. */
   }
   try {
     window.fbq?.('trackCustom', nomeMeta, params);
@@ -23,8 +24,12 @@ function enviar(nomeGa: string, nomeMeta: string, params: Params) {
   }
 }
 
+/* Código fora do formato do CRM não vira evento: cardinalidade do GA4 é
+   finita e a dimensão `codigo_vendedor` só deve receber código válido. */
 export function registrarChegadaIndicacao(codigo: string) {
-  enviar('indicacao_chegada', 'IndicacaoChegada', { codigo_vendedor: codigo });
+  const valido = normalizarCodigo(codigo);
+  if (!valido) return;
+  enviar('indicacao_chegada', 'IndicacaoChegada', { codigo_vendedor: valido });
 }
 
 export function registrarLeadIndicacao(
@@ -32,7 +37,7 @@ export function registrarLeadIndicacao(
   codigo: string | null
 ) {
   enviar('indicacao_lead', 'IndicacaoLead', {
-    codigo_vendedor: codigo ?? 'nenhum',
+    codigo_vendedor: normalizarCodigo(codigo) ?? 'nenhum',
     formulario
   });
 }

--- a/lib/analytics/indicacao.ts
+++ b/lib/analytics/indicacao.ts
@@ -1,0 +1,50 @@
+import { sendGAEvent } from '@next/third-parties/google';
+
+export type FormularioLead =
+  | 'contato'
+  | 'catalogo'
+  | 'montar-maquina'
+  | 'monte-fabrica'
+  | 'especificacoes';
+
+type Params = Record<string, string>;
+
+/* Nunca deixa analytics quebrar a página: GA ou Pixel ausentes viram no-op. */
+function enviar(nomeGa: string, nomeMeta: string, params: Params) {
+  try {
+    sendGAEvent('event', nomeGa, params);
+  } catch {
+    /* GA não carregado */
+  }
+  try {
+    window.fbq?.('trackCustom', nomeMeta, params);
+  } catch {
+    /* Pixel não carregado */
+  }
+}
+
+export function registrarChegadaIndicacao(codigo: string) {
+  enviar('indicacao_chegada', 'IndicacaoChegada', { codigo_vendedor: codigo });
+}
+
+export function registrarLeadIndicacao(
+  formulario: FormularioLead,
+  codigo: string | null
+) {
+  enviar('indicacao_lead', 'IndicacaoLead', {
+    codigo_vendedor: codigo ?? 'nenhum',
+    formulario
+  });
+}
+
+/** Devolve true na primeira chamada por sessão do navegador para este código. */
+export function marcarChegadaNaSessao(codigo: string): boolean {
+  const chave = `indicacao_registrada:${codigo}`;
+  try {
+    if (window.sessionStorage.getItem(chave)) return false;
+    window.sessionStorage.setItem(chave, '1');
+    return true;
+  } catch {
+    return false; // storage bloqueado: não registra, não quebra
+  }
+}

--- a/lib/crm/referral.ts
+++ b/lib/crm/referral.ts
@@ -1,3 +1,4 @@
+import { normalizarCodigo } from '@/lib/indicacao/codigo';
 import type { VendedorIndicacao } from '@/lib/indicacao/tipos';
 import { logger } from '@/lib/utils/logger';
 
@@ -9,8 +10,6 @@ export type ResultadoBusca =
   | { tipo: 'nao-encontrado' }
   | { tipo: 'indisponivel' };
 
-/** Mesmo formato que o CRM aceita; validar aqui evita rede para lixo de querystring. */
-const FORMATO_CODIGO = /^[A-Z0-9-]{3,20}$/;
 const CACHE_MS = 5 * 60 * 1000;
 const TIMEOUT_MS = 4000;
 /** Teto de entradas do cache; o processo é longo e o código vem de fora. */
@@ -57,12 +56,9 @@ export function tamanhoCacheReferral(): number {
   return cache.size;
 }
 
-export function normalizarCodigo(
-  valor: string | null | undefined
-): string | null {
-  const codigo = (valor ?? '').trim().toUpperCase();
-  return FORMATO_CODIGO.test(codigo) ? codigo : null;
-}
+/* Reexportado para não quebrar quem já importava daqui; a regra mora em
+   `lib/indicacao/codigo.ts`, que o cliente também pode importar. */
+export { normalizarCodigo };
 
 /**
  * Consulta o vendedor dono do código. Nunca lança: qualquer falha do CRM

--- a/lib/indicacao/codigo.ts
+++ b/lib/indicacao/codigo.ts
@@ -1,0 +1,13 @@
+/* Formato do código de vendedor, compartilhado entre servidor (CRM) e cliente
+   (analytics). Fica aqui, sem `server-only`, porque `lib/crm/referral.ts` é
+   server-only e o bundle do browser não pode importar de lá. */
+
+/** Mesmo formato que o CRM aceita; validar antes evita rede/eventos para lixo. */
+export const FORMATO_CODIGO = /^[A-Z0-9-]{3,20}$/;
+
+export function normalizarCodigo(
+  valor: string | null | undefined
+): string | null {
+  const codigo = (valor ?? '').trim().toUpperCase();
+  return FORMATO_CODIGO.test(codigo) ? codigo : null;
+}

--- a/types/fbq.d.ts
+++ b/types/fbq.d.ts
@@ -1,0 +1,6 @@
+/** Meta Pixel: o snippet do fbevents.js instala `fbq` em window depois da
+    hidratação. Fica aqui, e não no componente, para `lib/analytics` enxergar
+    o tipo sem importar a casca do layout. */
+interface Window {
+  fbq?: (...args: unknown[]) => void;
+}


### PR DESCRIPTION
Registra no GA4 e no Meta Pixel quando um código de vendedor é usado. Complementa a Indicação do PR #32.

Dois eventos, com os mesmos parâmetros nos dois lados. `indicacao_chegada` (GA) e `IndicacaoChegada` (Meta) saem uma vez por aba quando o browser lê o cookie de indicação, com `codigo_vendedor`; só nas páginas do grupo (site), porque o Provider não existe nas landings standalone. `indicacao_lead` e `IndicacaoLead` saem quando um dos cinco formulários recebe resposta 2xx, com `codigo_vendedor` e `formulario`. O código só entra no evento quando bate com o formato do CRM; lead sem indicação vai como `nenhum`, para comparar conversão com e sem vendedor. Nome, e-mail e telefone do vendedor nunca saem, e nada do lead sai.

Para o lead contar só quando o e-mail foi mesmo ao vendedor, os cinco route handlers devolvem `indicacao: { codigo } | null` no JSON de sucesso, calculado do destinatário já resolvido no servidor. Os cinco formulários leem esse campo no caminho de sucesso e disparam o evento, dois por hook e três direto no componente. Analytics ausente ou quebrado não afeta o envio nem a página.

No admin do GA4 as dimensões `codigo_vendedor` e `formulario` foram criadas hoje com escopo de evento na propriedade `profills-do-brasil`; os relatórios passam a mostrá-las em 24 a 48 h. No Meta os eventos customizados aparecem sozinhos no Gerenciador de Eventos.

Verificação: suíte, lint e tipos verdes. Smoke em dev server local com IDs falsos de GA e Pixel e cookie assinado mostrou `indicacao_chegada` uma vez por aba no `dataLayer`, zero disparos após reload, e `indicacao_lead` com o código e depois com `nenhum`, com a requisição real do Pixel levando `ev=IndicacaoLead` e `cd[codigo_vendedor]`. No smoke do lead a resposta do handler foi simulada no browser; o par handler e cliente está coberto pelos testes de rota. Revisão adversarial da branch, uma onda de correção e re-review escopada com os nove itens fechados. Ninguém viu ainda um evento chegando ao GA ou ao Gerenciador de Eventos reais; isso só acontece depois do deploy.

Limite conhecido, por decisão de produto: "chegada" conta uma vez por aba enquanto o cookie de indicação existir, e o cookie é renovado a cada 24 h de uso, então um visitante indicado que volta dias depois sem clicar em link nenhum conta de novo. Se o número precisar ser "cliques no link", o proxy tem de sinalizar a entrada; é uma mudança separada.
