### PR TITLE
fix: espera GA e Pixel antes dos eventos de indicação

### DIFF
--- a/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
+++ b/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
@@ -40,10 +40,17 @@ beforeEach(() => {
   vi.mocked(registrarLeadIndicacao).mockClear();
   vi.mocked(sendGAEvent).mockReset();
   vi.mocked(toast.error).mockClear();
+  /* registrarLeadIndicacao chama a implementação real, que só dispara na
+     hora se GA já estiver "pronto"; sem isso a tentativa cai num
+     setTimeout real e sobra timer pendente entre os testes. */
+  window.gtag = vi.fn();
+  window.dataLayer = [];
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  delete window.gtag;
+  delete window.dataLayer;
 });
 
 describe('useCatalogForm', () => {

--- a/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
+++ b/app/(site)/download/_components/catalog-form/hooks/useCatalogForm.test.ts
@@ -41,16 +41,19 @@ beforeEach(() => {
   vi.mocked(sendGAEvent).mockReset();
   vi.mocked(toast.error).mockClear();
   /* registrarLeadIndicacao chama a implementação real, que só dispara na
-     hora se GA já estiver "pronto"; sem isso a tentativa cai num
-     setTimeout real e sobra timer pendente entre os testes. */
+     hora se GA, dataLayer e Pixel já estiverem "prontos"; os três stubs
+     deixam a primeira tentativa síncrona, sem sobrar timer pendente (do GA
+     ou do Meta) entre os testes. */
   window.gtag = vi.fn();
   window.dataLayer = [];
+  window.fbq = vi.fn();
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
   delete window.gtag;
   delete window.dataLayer;
+  delete window.fbq;
 });
 
 describe('useCatalogForm', () => {

--- a/components/indicacao/indicacaoProvider.tsx
+++ b/components/indicacao/indicacaoProvider.tsx
@@ -64,10 +64,11 @@ export function IndicacaoProvider({ children }: { children: ReactNode }) {
      troca de referência quando o token do cookie muda, então o efeito não
      repete a cada render.
 
-     O evento só chega ao GA porque este efeito roda depois de o
-     `GoogleAnalytics` criar o `dataLayer`: o `useSyncExternalStore` força um
-     segundo commit e o efeito cai nele. `sendGAEvent` sem `dataLayer`
-     descarta o evento com um warn, não enfileira. */
+     A ordem entre este efeito e os scripts inline de GA e Pixel não é
+     garantida (na hidratação normal o segundo commit do
+     `useSyncExternalStore` cai depois deles; num render de cliente após
+     falha de hidratação, não). Por isso `lib/analytics/indicacao.ts` espera
+     cada script existir antes de disparar. */
   useEffect(() => {
     if (estado.status !== 'indicado') return;
     const codigo = estado.vendedor.codigo;

--- a/lib/analytics/indicacao.test.ts
+++ b/lib/analytics/indicacao.test.ts
@@ -140,6 +140,11 @@ describe('espera GA e Pixel ficarem prontos', () => {
     expect(ga).toHaveBeenCalledWith('event', 'indicacao_chegada', {
       codigo_vendedor: 'MARIA-10'
     });
+
+    vi.advanceTimersByTime(20000);
+
+    expect(ga).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('espera o Pixel aparecer', () => {
@@ -157,6 +162,11 @@ describe('espera GA e Pixel ficarem prontos', () => {
     expect(window.fbq).toHaveBeenCalledWith('trackCustom', 'IndicacaoChegada', {
       codigo_vendedor: 'MARIA-10'
     });
+
+    vi.advanceTimersByTime(20000);
+
+    expect(window.fbq).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('desiste em silêncio depois de 10 s', () => {
@@ -166,7 +176,10 @@ describe('espera GA e Pixel ficarem prontos', () => {
 
     expect(() => registrarChegadaIndicacao('MARIA-10')).not.toThrow();
 
-    vi.advanceTimersByTime(15000);
+    vi.advanceTimersByTime(9500);
+    expect(vi.getTimerCount()).toBe(2); // GA e Pixel pollam em paralelo
+
+    vi.advanceTimersByTime(500);
 
     expect(ga).not.toHaveBeenCalled();
     expect(window.fbq).toBeUndefined();
@@ -186,6 +199,11 @@ describe('espera GA e Pixel ficarem prontos', () => {
     vi.advanceTimersByTime(250);
 
     expect(window.fbq).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(20000);
+
+    expect(window.fbq).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });
 

--- a/lib/analytics/indicacao.test.ts
+++ b/lib/analytics/indicacao.test.ts
@@ -16,11 +16,15 @@ const ga = vi.mocked(sendGAEvent);
 beforeEach(() => {
   ga.mockReset();
   window.fbq = vi.fn();
+  window.gtag = vi.fn();
+  window.dataLayer = [];
   window.sessionStorage.clear();
 });
 
 afterEach(() => {
   delete window.fbq;
+  delete window.gtag;
+  delete window.dataLayer;
   window.sessionStorage.clear();
 });
 
@@ -106,6 +110,81 @@ describe('registrarLeadIndicacao', () => {
     });
 
     expect(() => registrarLeadIndicacao('contato', 'MARIA-10')).not.toThrow();
+    expect(window.fbq).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('espera GA e Pixel ficarem prontos', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('espera o GA aparecer', () => {
+    delete window.gtag;
+    delete window.dataLayer;
+
+    registrarChegadaIndicacao('MARIA-10');
+
+    expect(ga).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    window.gtag = vi.fn();
+    window.dataLayer = [];
+    vi.advanceTimersByTime(250);
+
+    expect(ga).toHaveBeenCalledTimes(1);
+    expect(ga).toHaveBeenCalledWith('event', 'indicacao_chegada', {
+      codigo_vendedor: 'MARIA-10'
+    });
+  });
+
+  it('espera o Pixel aparecer', () => {
+    delete window.fbq;
+
+    registrarChegadaIndicacao('MARIA-10');
+
+    expect(window.fbq).toBeUndefined();
+
+    vi.advanceTimersByTime(1000);
+    window.fbq = vi.fn();
+    vi.advanceTimersByTime(250);
+
+    expect(window.fbq).toHaveBeenCalledTimes(1);
+    expect(window.fbq).toHaveBeenCalledWith('trackCustom', 'IndicacaoChegada', {
+      codigo_vendedor: 'MARIA-10'
+    });
+  });
+
+  it('desiste em silêncio depois de 10 s', () => {
+    delete window.gtag;
+    delete window.dataLayer;
+    delete window.fbq;
+
+    expect(() => registrarChegadaIndicacao('MARIA-10')).not.toThrow();
+
+    vi.advanceTimersByTime(15000);
+
+    expect(ga).not.toHaveBeenCalled();
+    expect(window.fbq).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('os dois lados são independentes', () => {
+    delete window.fbq;
+
+    registrarChegadaIndicacao('MARIA-10');
+
+    expect(ga).toHaveBeenCalledTimes(1);
+    expect(window.fbq).toBeUndefined();
+
+    vi.advanceTimersByTime(2000);
+    window.fbq = vi.fn();
+    vi.advanceTimersByTime(250);
+
     expect(window.fbq).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/analytics/indicacao.ts
+++ b/lib/analytics/indicacao.ts
@@ -11,13 +11,14 @@ export type FormularioLead =
 type Params = Record<string, string>;
 
 const INTERVALO_MS = 250;
-const TENTATIVAS = 40; // 10 s
+const TENTATIVAS = 40; // cerca de 10 s (40 tentativas a cada 250 ms)
 
 /* GA e Pixel são instalados por scripts `afterInteractive`, que podem rodar
    depois do efeito que chama este módulo. `sendGAEvent` sem `dataLayer`
    descarta com warn (não enfileira) e `fbq` ausente é no-op, então cada lado
    espera o próprio script existir. Sem GA ou Pixel configurados, desiste em
-   silêncio depois de 10 s. Nunca lança. */
+   silêncio depois de cerca de 10 s (40 tentativas a cada 250 ms). Nunca
+   lança. */
 function quandoPronto(pronto: () => boolean, acao: () => void) {
   let tentativas = 0;
   const tentar = () => {
@@ -37,11 +38,17 @@ function quandoPronto(pronto: () => boolean, acao: () => void) {
     }
     tentativas += 1;
     if (tentativas >= TENTATIVAS) return;
-    window.setTimeout(tentar, INTERVALO_MS);
+    try {
+      window.setTimeout(tentar, INTERVALO_MS);
+    } catch {
+      /* sem `window` (SSR, ambiente sem timers): desiste */
+    }
   };
   tentar();
 }
 
+/* Acoplado ao dataLayerName padrão do @next/third-parties; se o layout
+   passar outro nome, ajustar aqui. */
 function gaPronto() {
   return typeof window.gtag === 'function' && Array.isArray(window.dataLayer);
 }

--- a/lib/analytics/indicacao.ts
+++ b/lib/analytics/indicacao.ts
@@ -10,18 +10,49 @@ export type FormularioLead =
 
 type Params = Record<string, string>;
 
-/* Nunca deixa analytics quebrar a página: GA ou Pixel ausentes viram no-op. */
+const INTERVALO_MS = 250;
+const TENTATIVAS = 40; // 10 s
+
+/* GA e Pixel são instalados por scripts `afterInteractive`, que podem rodar
+   depois do efeito que chama este módulo. `sendGAEvent` sem `dataLayer`
+   descarta com warn (não enfileira) e `fbq` ausente é no-op, então cada lado
+   espera o próprio script existir. Sem GA ou Pixel configurados, desiste em
+   silêncio depois de 10 s. Nunca lança. */
+function quandoPronto(pronto: () => boolean, acao: () => void) {
+  let tentativas = 0;
+  const tentar = () => {
+    let ok = false;
+    try {
+      ok = pronto();
+    } catch {
+      ok = false;
+    }
+    if (ok) {
+      try {
+        acao();
+      } catch {
+        /* dataLayer corrompido por extensão, fbq quebrado: não derruba a página */
+      }
+      return;
+    }
+    tentativas += 1;
+    if (tentativas >= TENTATIVAS) return;
+    window.setTimeout(tentar, INTERVALO_MS);
+  };
+  tentar();
+}
+
+function gaPronto() {
+  return typeof window.gtag === 'function' && Array.isArray(window.dataLayer);
+}
+
+function metaPronto() {
+  return typeof window.fbq === 'function';
+}
+
 function enviar(nomeGa: string, nomeMeta: string, params: Params) {
-  try {
-    sendGAEvent('event', nomeGa, params);
-  } catch {
-    /* GA ausente só gera warn; o catch cobre `dataLayer` corrompido por extensão. */
-  }
-  try {
-    window.fbq?.('trackCustom', nomeMeta, params);
-  } catch {
-    /* Pixel não carregado */
-  }
+  quandoPronto(gaPronto, () => sendGAEvent('event', nomeGa, params));
+  quandoPronto(metaPronto, () => window.fbq?.('trackCustom', nomeMeta, params));
 }
 
 /* Código fora do formato do CRM não vira evento: cardinalidade do GA4 é

--- a/types/analytics-globais.d.ts
+++ b/types/analytics-globais.d.ts
@@ -1,0 +1,10 @@
+/** `gtag` e `dataLayer` são criados pelo script inline do `<GoogleAnalytics>`
+    (não pelo gtag.js externo); `fbq`, pelo snippet do Pixel em
+    `components/layout/metaPixel.tsx`. Ambos instalam essas globais em
+    window depois da hidratação. Fica aqui, e não no componente, para
+    `lib/analytics` enxergar o tipo sem importar a casca do layout. */
+interface Window {
+  fbq?: (...args: unknown[]) => void;
+  gtag?: (...args: unknown[]) => void;
+  dataLayer?: unknown[];
+}

--- a/types/fbq.d.ts
+++ b/types/fbq.d.ts
@@ -1,6 +1,8 @@
-/** Meta Pixel: o snippet do fbevents.js instala `fbq` em window depois da
-    hidratação. Fica aqui, e não no componente, para `lib/analytics` enxergar
-    o tipo sem importar a casca do layout. */
+/** Meta Pixel e GA: os snippets do fbevents.js e do gtag.js instalam essas
+    globais em window depois da hidratação. Fica aqui, e não no componente,
+    para `lib/analytics` enxergar o tipo sem importar a casca do layout. */
 interface Window {
   fbq?: (...args: unknown[]) => void;
+  gtag?: (...args: unknown[]) => void;
+  dataLayer?: unknown[];
 }

--- a/types/fbq.d.ts
+++ b/types/fbq.d.ts
@@ -1,8 +1,0 @@
-/** Meta Pixel e GA: os snippets do fbevents.js e do gtag.js instalam essas
-    globais em window depois da hidratação. Fica aqui, e não no componente,
-    para `lib/analytics` enxergar o tipo sem importar a casca do layout. */
-interface Window {
-  fbq?: (...args: unknown[]) => void;
-  gtag?: (...args: unknown[]) => void;
-  dataLayer?: unknown[];
-}


### PR DESCRIPTION
Corrige a perda dos eventos de indicação em browsers reais. Segue o PR #33.

Em produção, um visitante que entrou por `?ref=OTHAVIO` gerou `page_view` no GA4, mas não `indicacao_chegada`. Em browser automatizado o evento sempre saiu. A diferença é a ordem de execução: o efeito do Provider pode rodar antes de o script inline do GA criar `window.dataLayer` e `gtag`, e o `sendGAEvent` do `@next/third-parties` descarta o evento com um aviso em vez de enfileirar. O `fbq` do Meta tem o mesmo problema quando o snippet ainda não rodou.

Agora `lib/analytics/indicacao.ts` espera cada lado ficar pronto: `gtag` com `dataLayer` para o GA, `fbq` para o Meta, com tentativa síncrona na hora e depois polling de 250 ms por até 10 s, cada lado independente. Sem GA ou Pixel configurados, desiste em silêncio. Com os dois já prontos, o comportamento é o de antes. Nada muda nos handlers, nos formulários nem no Provider.

Testes novos cobrem GA aparecendo tarde, Pixel aparecendo tarde, nenhum dos dois aparecendo e os dois lados independentes. Suíte, lint e tipos verdes. A revisão da branch mostrou, com uma sonda no React 19, que na hidratação normal o efeito do Provider já cai depois dos scripts; a ordem só inverte quando a hidratação falha e o React refaz a página no cliente. A correção cobre esse caminho e não custa nada no caminho normal, mas não é prova de que foi isso que aconteceu no teste em produção; outras causas com o mesmo sintoma são cookie não gravado (código não resolvido no CRM) e aba já marcada em sessionStorage por uma visita anterior.

Verificação depois do merge: abrir `https://www.profills.com/?ref=OTHAVIO` numa aba nova de um browser sem bloqueador e conferir `indicacao_chegada` em GA4 → Tempo real, e `IndicacaoChegada` no Gerenciador de Eventos do Meta.
